### PR TITLE
Delete unused _dbName property in CursorApiClientTest.

### DIFF
--- a/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
+++ b/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
@@ -13,7 +13,6 @@ namespace ArangoDBNetStandardTest.CursorApi
 {
     public class CursorApiClientTest : IClassFixture<CursorApiClientTestFixture>
     {
-        private readonly string _dbName = nameof(CursorApiClientTest);
         private CursorApiClient _cursorApi;
 
         public class MyModel


### PR DESCRIPTION
A minor commit to get my first contribution going.

This resolves a warning in the build caused by a an unused property in tests. #9 