### PR TITLE
Update XUnit from 2.4.0 to 2.4.1.

### DIFF
--- a/arangodb-net-standard.Test/ArangoDBNetStandardTest.csproj
+++ b/arangodb-net-standard.Test/ArangoDBNetStandardTest.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated the version of XUnit test framework we use in ArangoDBNetStandardTest from 2.4.0 to 2.4.1. #17 