### PR TITLE
#25 Add tests for Truncate Collection

### DIFF
--- a/arangodb-net-standard.Test/CollectionApi/CollectionApiClientTestFixture.cs
+++ b/arangodb-net-standard.Test/CollectionApi/CollectionApiClientTestFixture.cs
@@ -1,11 +1,14 @@
 ﻿using System.Threading.Tasks;
 using ArangoDBNetStandard;
+using ArangoDBNetStandard.CollectionApi;
 
 namespace ArangoDBNetStandardTest.CollectionApi
 {
     public class CollectionApiClientTestFixture : ApiClientTestFixtureBase
     {
         public ArangoDBClient ArangoDBClient { get; internal set; }
+
+        public string TestCollection { get; } = "TestCollection";
 
         public CollectionApiClientTestFixture()
         {
@@ -20,6 +23,12 @@ namespace ArangoDBNetStandardTest.CollectionApi
             await CreateDatabase(dbName);
 
             ArangoDBClient = GetArangoDBClient(dbName);
+
+            await ArangoDBClient.Collection.PostCollectionAsync(
+                new PostCollectionRequest
+                {
+                    Name = TestCollection
+                });
         }
     }
 }

--- a/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
+++ b/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
@@ -31,7 +31,7 @@ namespace ArangoDBNetStandardTest.DocumentApi
             _docClient = _adb.Document;
 
             // Truncate TestCollection before each test
-            _adb.Collection.PutCollectionTruncateAsync(fixture.TestCollection)
+            _adb.Collection.TruncateCollectionAsync(fixture.TestCollection)
                 .GetAwaiter()
                 .GetResult();
         }

--- a/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
+++ b/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
@@ -14,8 +14,8 @@ namespace ArangoDBNetStandardTest.TransactionApi
         public TransactionApiClientTest(TransactionApiClientTestFixture fixture)
         {
             _adb = fixture.ArangoDBClient;
-            _adb.Collection.PutCollectionTruncateAsync(fixture.TestCollection1).Wait();
-            _adb.Collection.PutCollectionTruncateAsync(fixture.TestCollection2).Wait();
+            _adb.Collection.TruncateCollectionAsync(fixture.TestCollection1).Wait();
+            _adb.Collection.TruncateCollectionAsync(fixture.TestCollection2).Wait();
         }
 
         [Fact]

--- a/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
@@ -1,9 +1,7 @@
-﻿using ArangoDBNetStandard.Transport;
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Text;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
+
+using ArangoDBNetStandard.Transport;
 
 namespace ArangoDBNetStandard.CollectionApi
 {
@@ -49,14 +47,23 @@ namespace ArangoDBNetStandard.CollectionApi
             throw new ApiErrorException(error);
         }
 
-        public async Task PutCollectionTruncateAsync(string collectionName)
+        /// <summary>
+        /// Truncates a collection, i.e. removes all documents in the collection.
+        /// PUT/_api/collection/{collection-name}/truncate
+        /// </summary>
+        /// <param name="collectionName"></param>
+        /// <returns></returns>
+        public async Task<TruncateCollectionResult> TruncateCollectionAsync(string collectionName)
         {
-            var response = await _transport.PutAsync(_collectionApiPath + "/" + collectionName + "/truncate", null);
-            if (response.IsSuccessStatusCode)
+            using (var response = await _transport.PutAsync(_collectionApiPath + "/" + collectionName + "/truncate", null))
             {
-                return;
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<TruncateCollectionResult>(stream, true, false);
+                }
+                throw await GetApiErrorException(response);
             }
-            await GetApiErrorException(response);
         }
     }
 }

--- a/arangodb-net-standard/CollectionApi/TruncateCollectionResult.cs
+++ b/arangodb-net-standard/CollectionApi/TruncateCollectionResult.cs
@@ -1,0 +1,23 @@
+﻿using System.Net;
+
+namespace ArangoDBNetStandard.CollectionApi
+{
+    public class TruncateCollectionResult
+    {
+        public bool Error { get; set; }
+
+        public HttpStatusCode Code { get; set; }
+
+        public int Status { get; set; }
+
+        public string Name { get; set; }
+
+        public int Type { get; set; }
+
+        public bool IsSystem { get; set; }
+
+        public string GloballyUniqueId { get; set; }
+
+        public string Id { get; set; }
+    }
+}

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -29,7 +29,7 @@ A tick indicates an item is implemented and has automated tests in place.
 - [ ]	PUT/_api/collection/{collection-name}/properties Change properties of a collection
 - [ ]	PUT/_api/collection/{collection-name}/rename Rename collection
 - [ ]	GET/_api/collection/{collection-name}/revision Return collection revision id
-- [ ]	PUT/_api/collection/{collection-name}/truncate Truncate collection
+- [X]	PUT/_api/collection/{collection-name}/truncate Truncate collection
 
 #### Cursor API
 


### PR DESCRIPTION
#25 Add tests for Truncate Collection

Also implemented TruncateCollectionResponse model to capture the properties returned by this endpoint.