### PR TITLE
Introduce special handling for dictionary serialization

### DIFF
--- a/arangodb-net-standard.Test/Serialization/JsonNetApiClientSerializationTest.cs
+++ b/arangodb-net-standard.Test/Serialization/JsonNetApiClientSerializationTest.cs
@@ -53,6 +53,30 @@ namespace ArangoDBNetStandardTest.Serialization
         }
 
         [Fact]
+        public void Serialize_ShouldNotCamelCaseParams_WhenSerializingPostTransactionBody()
+        {
+            var body = new PostTransactionBody
+            {
+                Params = new Dictionary<string, object>
+                {
+                    ["DontCamelCaseKey"] = new { DontCamelCaseMe = true }
+                }
+            };
+
+            var serialization = new JsonNetApiClientSerialization();
+
+            byte[] jsonBytes = serialization.Serialize(body, true, true);
+
+            string jsonString = Encoding.UTF8.GetString(jsonBytes);
+
+            Assert.Contains("DontCamelCaseMe", jsonString);
+            Assert.Contains("DontCamelCaseKey", jsonString);
+            Assert.DoesNotContain("dontCamelCaseMe", jsonString);
+            Assert.DoesNotContain("dontCamelCaseKey", jsonString);
+        }
+
+
+        [Fact]
         public void Serialize_ShouldNotIgnoreNull_WhenSerializingPostCursorBody()
         {
             var body = new PostCursorBody

--- a/arangodb-net-standard.Test/Serialization/JsonNetApiClientSerializationTest.cs
+++ b/arangodb-net-standard.Test/Serialization/JsonNetApiClientSerializationTest.cs
@@ -1,5 +1,8 @@
-﻿using ArangoDBNetStandard.Serialization;
+﻿using ArangoDBNetStandard.CursorApi.Models;
+using ArangoDBNetStandard.Serialization;
+using ArangoDBNetStandard.TransactionApi.Models;
 using ArangoDBNetStandardTest.Serialization.Models;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using Xunit;
@@ -25,6 +28,68 @@ namespace ArangoDBNetStandardTest.Serialization
 
             Assert.Contains("propertyToCamelCase", jsonString);
             Assert.DoesNotContain("nullPropertyToIgnore", jsonString);
+        }
+
+        [Fact]
+        public void Serialize_ShouldNotCamelCaseBindVars_WhenSerializingPostCursorBody()
+        {
+            var body = new PostCursorBody
+            {
+                BindVars = new Dictionary<string, object>
+                {
+                    ["DontCamelCaseKey"] = new { DontCamelCaseMe = true }
+                }
+            };
+            var serialization = new JsonNetApiClientSerialization();
+
+            byte[] jsonBytes = serialization.Serialize(body, true, true);
+
+            string jsonString = Encoding.UTF8.GetString(jsonBytes);
+
+            Assert.Contains("DontCamelCaseMe", jsonString);
+            Assert.Contains("DontCamelCaseKey", jsonString);
+            Assert.DoesNotContain("dontCamelCaseMe", jsonString);
+            Assert.DoesNotContain("dontCamelCaseKey", jsonString);
+        }
+
+        [Fact]
+        public void Serialize_ShouldNotIgnoreNull_WhenSerializingPostCursorBody()
+        {
+            var body = new PostCursorBody
+            {
+                BindVars = new Dictionary<string, object>
+                {
+                    ["DontCamelCaseKey"] = null
+                }
+            };
+            var serialization = new JsonNetApiClientSerialization();
+
+            byte[] jsonBytes = serialization.Serialize(body, true, true);
+
+            string jsonString = Encoding.UTF8.GetString(jsonBytes);
+
+            Assert.Contains("DontCamelCaseKey", jsonString);
+        }
+
+
+        [Fact]
+        public void Serialize_ShouldNotIgnoreNull_WhenSerializingPostTransactionBody()
+        {
+            var body = new PostTransactionBody
+            {
+                Params = new Dictionary<string, object>
+                {
+                    ["DontCamelCaseKey"] = null
+                }
+            };
+
+            var serialization = new JsonNetApiClientSerialization();
+
+            byte[] jsonBytes = serialization.Serialize(body, true, true);
+
+            string jsonString = Encoding.UTF8.GetString(jsonBytes);
+
+            Assert.Contains("DontCamelCaseKey", jsonString);
         }
 
         [Fact]

--- a/arangodb-net-standard/Serialization/CamelCasePropertyNamesExceptDictionaryContractResolver.cs
+++ b/arangodb-net-standard/Serialization/CamelCasePropertyNamesExceptDictionaryContractResolver.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json.Serialization;
+using System;
+
+namespace ArangoDBNetStandard.Serialization
+{
+    /// <summary>
+    /// Custom  <see cref="IContractResolver"></see> implementation designed for special handling of
+    /// dictionaries where we do not want to camel-case keys or values, nor ignore null values, 
+    /// on serialization.
+    /// </summary>
+    public class CamelCasePropertyNamesExceptDictionaryContractResolver : DefaultContractResolver
+    {
+        public CamelCasePropertyNamesExceptDictionaryContractResolver()
+        {
+            NamingStrategy = new CamelCaseNamingStrategy();
+        }
+
+        protected override JsonDictionaryContract CreateDictionaryContract(Type objectType)
+        {
+            JsonDictionaryContract contract = base.CreateDictionaryContract(objectType);
+            contract.DictionaryKeyResolver = propertyName => propertyName;
+            contract.ItemConverter = new DictionaryValueConverter();
+            return contract;
+        }
+    }
+
+}

--- a/arangodb-net-standard/Serialization/DictionaryValueConverter.cs
+++ b/arangodb-net-standard/Serialization/DictionaryValueConverter.cs
@@ -1,0 +1,34 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace ArangoDBNetStandard.Serialization
+{
+    /// <summary>
+    /// Provides special handling for dictionaries where we do not want to camel-case convert 
+    /// nor ignore null values upon serialization.
+    /// </summary>
+    public class DictionaryValueConverter : JsonConverter
+    {
+        private static JsonSerializer _serializer = new JsonSerializer
+        {
+            NullValueHandling = NullValueHandling.Include
+        };
+
+        public override bool CanConvert(Type objectType)
+        {
+            return true;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return serializer.Deserialize(reader);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            // Use our local serializer for writing instead of the passed-in serializer
+            _serializer.Serialize(writer, value);
+        }
+    }
+
+}

--- a/arangodb-net-standard/Serialization/JsonNetApiClientSerialization.cs
+++ b/arangodb-net-standard/Serialization/JsonNetApiClientSerialization.cs
@@ -1,6 +1,9 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
 using System.Text;
 
 namespace ArangoDBNetStandard.Serialization
@@ -56,7 +59,7 @@ namespace ArangoDBNetStandard.Serialization
 
             if (useCamelCasePropertyNames)
             {
-                jsonSettings.ContractResolver = new CamelCasePropertyNamesContractResolver();
+                jsonSettings.ContractResolver = new CamelCasePropertyNamesExceptDictionaryContractResolver();
             }
 
             string json = JsonConvert.SerializeObject(item, jsonSettings);


### PR DESCRIPTION
bug/#189

This prevents camel-casing or ignoring null values for user-specified
values used for cursor request bindVars or transaction params.