### PR TITLE
Use query string in PostCollectionAsync.

### DIFF
--- a/arangodb-net-standard.Test/ArangoDBNetStandardTest.csproj
+++ b/arangodb-net-standard.Test/ArangoDBNetStandardTest.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
@@ -46,7 +46,7 @@ namespace ArangoDBNetStandard.CollectionApi
                 uriString += "?" + options.ToQueryString();
             }
             var content = GetContent(body, true, true);
-            using (var response = await _transport.PostAsync(_collectionApiPath, content))
+            using (var response = await _transport.PostAsync(uriString, content))
             {
                 var stream = await response.Content.ReadAsStreamAsync();
                 if (response.IsSuccessStatusCode)


### PR DESCRIPTION
fix #208

The api path variable was used for the request. Passing the query string variable instead solved the issue.
I added a test to verify that the query string is built properly. To mock the transport layer, I added a dependency to the [Moq package](https://www.nuget.org/packages/moq/).