### PR TITLE
Add a class for query parameters of DeleteDocumentAsync.

### DIFF
--- a/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
+++ b/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
@@ -67,7 +67,7 @@ namespace ArangoDBNetStandardTest.DocumentApi
             var response = await _docClient.PostDocumentAsync(_testCollection, document);
             Assert.NotNull(response._id);
 
-            var deleteResponse = await _docClient.DeleteDocumentAsync<MyTestClass>(response._id, new DeleteDocumentsQuery
+            var deleteResponse = await _docClient.DeleteDocumentAsync<MyTestClass>(response._id, new DeleteDocumentQuery
             {
                 ReturnOld = true
             });
@@ -81,6 +81,47 @@ namespace ArangoDBNetStandardTest.DocumentApi
                 await _docClient.GetDocumentAsync<object>(response._id));
 
             Assert.Equal(NOT_FOUND_NUM, ex.ApiError.ErrorNum); // document not found
+        }
+
+        [Fact]
+        public async Task DeleteDocument_ShouldUseQueryParameters_WhenProvided()
+        {
+            var mockTransport = new Mock<IApiClientTransport>();
+
+            var mockResponse = new Mock<IApiClientResponse>();
+
+            var mockResponseContent = new Mock<IApiClientResponseContent>();
+
+            mockResponse.Setup(x => x.Content)
+                .Returns(mockResponseContent.Object);
+
+            mockResponse.Setup(x => x.IsSuccessStatusCode)
+                .Returns(true);
+
+            string requestUri = null;
+
+            mockTransport.Setup(x => x.DeleteAsync(It.IsAny<string>()))
+                .Returns((string uri) =>
+                {
+                    requestUri = uri;
+                    return Task.FromResult(mockResponse.Object);
+                });
+
+            var client = new DocumentApiClient(mockTransport.Object);
+
+            await client.DeleteDocumentAsync(
+                "mycollection/0123456789",
+                new DeleteDocumentQuery
+                {
+                    ReturnOld = true,
+                    Silent = true,
+                    WaitForSync = true
+                });
+
+            Assert.NotNull(requestUri);
+            Assert.Contains("returnOld=true", requestUri);
+            Assert.Contains("silent=true", requestUri);
+            Assert.Contains("waitForSync=true", requestUri);
         }
 
         [Fact]
@@ -215,6 +256,50 @@ namespace ArangoDBNetStandardTest.DocumentApi
                 });
 
             Assert.Empty(deleteResponse);
+        }
+
+        [Fact]
+        public async Task DeleteDocuments_ShouldUseQueryParameters_WhenProvided()
+        {
+            var mockTransport = new Mock<IApiClientTransport>();
+
+            var mockResponse = new Mock<IApiClientResponse>();
+
+            var mockResponseContent = new Mock<IApiClientResponseContent>();
+
+            mockResponse.Setup(x => x.Content)
+                .Returns(mockResponseContent.Object);
+
+            mockResponse.Setup(x => x.IsSuccessStatusCode)
+                .Returns(true);
+
+            string requestUri = null;
+
+            mockTransport.Setup(x => x.DeleteAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Returns((string uri, byte[] content) =>
+                {
+                    requestUri = uri;
+                    return Task.FromResult(mockResponse.Object);
+                });
+
+            var client = new DocumentApiClient(mockTransport.Object);
+
+            await client.DeleteDocumentsAsync(
+                "mycollection",
+                new List<string>() { "0123456789" },
+                new DeleteDocumentsQuery
+                {
+                    IgnoreRevs = true,
+                    ReturnOld = true,
+                    Silent = true,
+                    WaitForSync = true
+                });
+
+            Assert.NotNull(requestUri);
+            Assert.Contains("ignoreRevs=true", requestUri);
+            Assert.Contains("returnOld=true", requestUri);
+            Assert.Contains("silent=true", requestUri);
+            Assert.Contains("waitForSync=true", requestUri);
         }
 
         [Fact]

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -197,16 +197,21 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <remarks>
         /// This method overload is provided as a convenience when the client does not care about the type of <see cref="DeleteDocumentResponse{T}.Old"/>
         /// in the returned <see cref="DeleteDocumentResponse{object}"/>. Its value will be <see cref="null"/> when 
-        /// <see cref="DeleteDocumentsQuery.ReturnOld"/> is either <see cref="false"/> or not set, so this overload is useful in the default case 
+        /// <see cref="DeleteDocumentQuery.ReturnOld"/> is either <see cref="false"/> or not set, so this overload is useful in the default case 
         /// when deleting documents.
         /// </remarks>
         /// <param name="collectionName"></param>
         /// <param name="documentKey"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteDocumentResponse<object>> DeleteDocumentAsync(string collectionName, string documentKey, DeleteDocumentsQuery query = null)
+        public async Task<DeleteDocumentResponse<object>> DeleteDocumentAsync(
+            string collectionName,
+            string documentKey,
+            DeleteDocumentQuery query = null)
         {
-            return await DeleteDocumentAsync<object>($"{WebUtility.UrlEncode(collectionName)}/{WebUtility.UrlEncode(documentKey)}", query);
+            return await DeleteDocumentAsync<object>(
+                $"{WebUtility.UrlEncode(collectionName)}/{WebUtility.UrlEncode(documentKey)}",
+                query);
         }
 
         /// <summary>
@@ -215,15 +220,63 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <remarks>
         /// This method overload is provided as a convenience when the client does not care about the type of <see cref="DeleteDocumentResponse{T}.Old"/>
         /// in the returned <see cref="DeleteDocumentResponse{object}"/>. Its value will be <see cref="null"/> when 
-        /// <see cref="DeleteDocumentsQuery.ReturnOld"/> is either <see cref="false"/> or not set, so this overload is useful in the default case 
+        /// <see cref="DeleteDocumentQuery.ReturnOld"/> is either <see cref="false"/> or not set, so this overload is useful in the default case 
         /// when deleting documents.
         /// </remarks>
         /// <param name="documentId"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteDocumentResponse<object>> DeleteDocumentAsync(string documentId, DeleteDocumentsQuery query = null)
+        public async Task<DeleteDocumentResponse<object>> DeleteDocumentAsync(
+            string documentId,
+            DeleteDocumentQuery query = null)
         {
             return await DeleteDocumentAsync<object>(documentId, query);
+        }
+
+        /// <summary>
+        /// Delete a document.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="collectionName"></param>
+        /// <param name="documentKey"></param>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        public async Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(
+            string collectionName,
+            string documentKey,
+            DeleteDocumentQuery query = null)
+        {
+            return await DeleteDocumentAsync<T>(
+                $"{WebUtility.UrlEncode(collectionName)}/{WebUtility.UrlEncode(documentKey)}",
+                query);
+        }
+
+        /// <summary>
+        /// Delete a document based on its document ID.
+        /// </summary>
+        /// <param name="documentId"></param>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        public async Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(
+            string documentId,
+            DeleteDocumentQuery query = null)
+        {
+            ValidateDocumentId(documentId);
+            string uri = _docApiPath + "/" + documentId;
+            if (query != null)
+            {
+                uri += "?" + query.ToQueryString();
+            }
+            using (var response = await _client.DeleteAsync(uri))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    var responseModel = DeserializeJsonFromStream<DeleteDocumentResponse<T>>(stream);
+                    return responseModel;
+                }
+                throw await GetApiErrorException(response);
+            }
         }
 
         /// <summary>
@@ -243,45 +296,6 @@ namespace ArangoDBNetStandard.DocumentApi
         public async Task<DeleteDocumentsResponse<object>> DeleteDocumentsAsync(string collectionName, IList<string> selectors, DeleteDocumentsQuery query = null)
         {
             return await DeleteDocumentsAsync<object>(collectionName, selectors, query);
-        }
-
-        /// <summary>
-        /// Delete a document.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="collectionName"></param>
-        /// <param name="documentKey"></param>
-        /// <param name="query"></param>
-        /// <returns></returns>
-        public async Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(string collectionName, string documentKey, DeleteDocumentsQuery query = null)
-        {
-            return await DeleteDocumentAsync<T>($"{WebUtility.UrlEncode(collectionName)}/{WebUtility.UrlEncode(documentKey)}", query);
-        }
-
-        /// <summary>
-        /// Delete a document based on its document ID.
-        /// </summary>
-        /// <param name="documentId"></param>
-        /// <param name="query"></param>
-        /// <returns></returns>
-        public async Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(string documentId, DeleteDocumentsQuery query = null)
-        {
-            ValidateDocumentId(documentId);
-            string uri = _docApiPath + "/" + documentId;
-            if (query != null)
-            {
-                uri += "?" + query.ToQueryString();
-            }
-            using (var response = await _client.DeleteAsync(uri))
-            {
-                if (response.IsSuccessStatusCode)
-                {
-                    var stream = await response.Content.ReadAsStreamAsync();
-                    var responseModel = DeserializeJsonFromStream<DeleteDocumentResponse<T>>(stream);
-                    return responseModel;
-                }
-                throw await GetApiErrorException(response);
-            }
         }
 
         /// <summary>

--- a/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
@@ -88,7 +88,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <remarks>
         /// This method overload is provided as a convenience when the client does not care about the type of <see cref="DeleteDocumentResponse{T}.Old"/>
         /// in the returned <see cref="DeleteDocumentResponse{object}"/>. Its value will be <see cref="null"/> when 
-        /// <see cref="DeleteDocumentsQuery.ReturnOld"/> is either <see cref="false"/> or not set, so this overload is useful in the default case 
+        /// <see cref="DeleteDocumentQuery.ReturnOld"/> is either <see cref="false"/> or not set, so this overload is useful in the default case 
         /// when deleting documents.
         /// </remarks>
         /// <param name="collectionName"></param>
@@ -98,7 +98,7 @@ namespace ArangoDBNetStandard.DocumentApi
         Task<DeleteDocumentResponse<object>> DeleteDocumentAsync(
             string collectionName,
             string documentKey,
-            DeleteDocumentsQuery query = null);
+            DeleteDocumentQuery query = null);
 
         /// <summary>
         /// Delete a document based on its document ID.
@@ -106,7 +106,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <remarks>
         /// This method overload is provided as a convenience when the client does not care about the type of <see cref="DeleteDocumentResponse{T}.Old"/>
         /// in the returned <see cref="DeleteDocumentResponse{object}"/>. Its value will be <see cref="null"/> when 
-        /// <see cref="DeleteDocumentsQuery.ReturnOld"/> is either <see cref="false"/> or not set, so this overload is useful in the default case 
+        /// <see cref="DeleteDocumentQuery.ReturnOld"/> is either <see cref="false"/> or not set, so this overload is useful in the default case 
         /// when deleting documents.
         /// </remarks>
         /// <param name="documentId"></param>
@@ -114,7 +114,30 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <returns></returns>
         Task<DeleteDocumentResponse<object>> DeleteDocumentAsync(
             string documentId,
-            DeleteDocumentsQuery query = null);
+            DeleteDocumentQuery query = null);
+
+        /// <summary>
+        /// Delete a document.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="collectionName"></param>
+        /// <param name="documentKey"></param>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(
+          string collectionName,
+          string documentKey,
+          DeleteDocumentQuery query = null);
+
+        /// <summary>
+        /// Delete a document based on its document ID.
+        /// </summary>
+        /// <param name="documentId"></param>
+        /// <param name="query"></param>
+        /// <returns></returns>
+        Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(
+          string documentId,
+          DeleteDocumentQuery query = null);
 
         /// <summary>
         /// Delete multiple documents based on the passed document selectors.
@@ -133,29 +156,6 @@ namespace ArangoDBNetStandard.DocumentApi
         Task<DeleteDocumentsResponse<object>> DeleteDocumentsAsync(
           string collectionName,
           IList<string> selectors,
-          DeleteDocumentsQuery query = null);
-
-        /// <summary>
-        /// Delete a document.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="collectionName"></param>
-        /// <param name="documentKey"></param>
-        /// <param name="query"></param>
-        /// <returns></returns>
-        Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(
-          string collectionName,
-          string documentKey,
-          DeleteDocumentsQuery query = null);
-
-        /// <summary>
-        /// Delete a document based on its document ID.
-        /// </summary>
-        /// <param name="documentId"></param>
-        /// <param name="query"></param>
-        /// <returns></returns>
-        Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(
-          string documentId,
           DeleteDocumentsQuery query = null);
 
         /// <summary>

--- a/arangodb-net-standard/DocumentApi/Models/DeleteDocumentQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/DeleteDocumentQuery.cs
@@ -1,11 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace ArangoDBNetStandard.DocumentApi.Models
 {
     /// <summary>
-    /// Represents query parameters used when deleting multiple document.
+    /// Represents query parameters used when deleting a single document.
     /// </summary>
-    public class DeleteDocumentsQuery
+    public class DeleteDocumentQuery
     {
         /// <summary>
         /// Wait until deletion operation has been synced to disk.
@@ -17,12 +19,6 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         /// under the <see cref="DeleteDocumentResponse{T}.Old"/>.
         /// </summary>
         public bool? ReturnOld { get; set; }
-
-        /// <summary>
-        /// If set to true, ignore any _rev attribute in the selectors.
-        /// No revision check is performed.
-        /// </summary>
-        public bool? IgnoreRevs { get; set; }
 
         /// <summary>
         /// If set to true, an empty object will be returned as response.
@@ -41,10 +37,6 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (ReturnOld != null)
             {
                 queryParams.Add("returnOld=" + ReturnOld.ToString().ToLower());
-            }
-            if (IgnoreRevs != null)
-            {
-                queryParams.Add("ignoreRevs=" + IgnoreRevs.ToString().ToLower());
             }
             if (Silent != null)
             {


### PR DESCRIPTION
fix #230

I kept the `Silent` parameter in `DeleteDocumentsQuery` because it works, it was probably not documented by mistake.

Also:
- added tests for query parameters of `DeleteDocumentAsync` and `DeleteDocumentsAsync`.
- grouped `DeleteDocumentAsync` and `DeleteDocumentsAsync` methods together in the file