### PR TITLE
Cleanup document ID validation message.

### DIFF
--- a/arangodb-net-standard/ApiClientBase.cs
+++ b/arangodb-net-standard/ApiClientBase.cs
@@ -31,8 +31,8 @@ namespace ArangoDBNetStandard
         {
             if (documentId.Split('/').Length != 2)
             {
-                throw new ArgumentException("A valid document ID has two parts, split by '/'. + " +
-                    "" + documentId + " is not a valid document ID. Maybe the document key was used by mistake?");
+                throw new ArgumentException("A valid document ID has two parts, split by '/'. \"" +
+                    documentId + "\" is not a valid document ID. Maybe the document key was used by mistake?");
             }
         }
 


### PR DESCRIPTION
fix #231

Also wrapped the document ID into quotes "".