### PR TITLE
Return empty response when silent is true.

### DIFF
--- a/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
+++ b/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
@@ -195,6 +195,29 @@ namespace ArangoDBNetStandardTest.DocumentApi
         }
 
         [Fact]
+        public async Task DeleteDocuments_ShouldSucceed_WhenSilent()
+        {
+            var createResponse = await _docClient.PostDocumentsAsync(
+                _testCollection,
+                new object[] {
+                    new { testKey = "testValue" },
+                    new { testKey = "testValue" }
+                });
+
+            Assert.Equal(2, createResponse.Count);
+
+            var deleteResponse = await _docClient.DeleteDocumentsAsync(
+                _testCollection,
+                createResponse.Select(x => x._key).ToList(),
+                new DeleteDocumentsQuery()
+                {
+                    Silent = true
+                });
+
+            Assert.Empty(deleteResponse);
+        }
+
+        [Fact]
         public async Task DeleteDocuments_ShouldNotThrowButReportFailure_WhenSomeDocumentSelectorsAreInvalid()
         {
             var docs = new[] {
@@ -341,6 +364,23 @@ namespace ArangoDBNetStandardTest.DocumentApi
                 Assert.Null(innerResponse.Old);
                 Assert.Equal("value", (string)innerResponse.New.test);
             }
+        }
+
+        [Fact]
+        public async Task PostDocuments_ShouldSucceed_WhenSilent()
+        {
+            var createResponse = await _docClient.PostDocumentsAsync(
+                _testCollection,
+                new object[] {
+                    new { testKey = "testValue" },
+                    new { testKey = "testValue" }
+                },
+                new PostDocumentsQuery()
+                {
+                    Silent = true
+                });
+
+            Assert.Empty(createResponse);
         }
 
         [Fact]

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -85,8 +85,15 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 if (response.IsSuccessStatusCode)
                 {
-                    var stream = await response.Content.ReadAsStreamAsync();
-                    return DeserializeJsonFromStream<PostDocumentsResponse<T>>(stream);
+                    if (query != null && query.Silent.HasValue && query.Silent.Value)
+                    {
+                        return PostDocumentsResponse<T>.Empty();
+                    }
+                    else
+                    {
+                        var stream = await response.Content.ReadAsStreamAsync();
+                        return DeserializeJsonFromStream<PostDocumentsResponse<T>>(stream);
+                    }
                 }
                 throw await GetApiErrorException(response);
             }
@@ -298,9 +305,15 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 if (response.IsSuccessStatusCode)
                 {
-                    var stream = await response.Content.ReadAsStreamAsync();
-                    var responseModel = DeserializeJsonFromStream<DeleteDocumentsResponse<T>>(stream);
-                    return responseModel;
+                    if (query != null && query.Silent.HasValue && query.Silent.Value)
+                    {
+                        return DeleteDocumentsResponse<T>.Empty();
+                    }
+                    else
+                    {
+                        var stream = await response.Content.ReadAsStreamAsync();
+                        return DeserializeJsonFromStream<DeleteDocumentsResponse<T>>(stream);
+                    }
                 }
                 throw await GetApiErrorException(response);
             }

--- a/arangodb-net-standard/DocumentApi/Models/DeleteDocumentsResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/DeleteDocumentsResponse.cs
@@ -2,7 +2,20 @@
 
 namespace ArangoDBNetStandard.DocumentApi.Models
 {
-    public class DeleteDocumentsResponse<T>: List<DeleteDocumentsDocumentResponse<T>>
+    public class DeleteDocumentsResponse<T> : List<DeleteDocumentsDocumentResponse<T>>
     {
+        public DeleteDocumentsResponse()
+        {
+        }
+
+        private DeleteDocumentsResponse(int capacity)
+            : base(capacity)
+        {
+        }
+
+        public static DeleteDocumentsResponse<T> Empty()
+        {
+            return new DeleteDocumentsResponse<T>(0);
+        }
     }
 }

--- a/arangodb-net-standard/DocumentApi/Models/PostDocumentsResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PostDocumentsResponse.cs
@@ -6,8 +6,20 @@ namespace ArangoDBNetStandard.DocumentApi.Models
     /// Response after posting multiple documents
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class PostDocumentsResponse<T>: List<PostDocumentsDocumentResponse<T>>
+    public class PostDocumentsResponse<T> : List<PostDocumentsDocumentResponse<T>>
     {
+        public PostDocumentsResponse()
+        {
+        }
 
+        private PostDocumentsResponse(int capacity)
+            : base(capacity)
+        {
+        }
+
+        public static PostDocumentsResponse<T> Empty()
+        {
+            return new PostDocumentsResponse<T>(0);
+        }
     }
 }


### PR DESCRIPTION
fix #233

Don't deserialize response if silent `query` parameter is true for `PostDocumentsAsync` and `DeleteDocumentsAsync`, instead return an empty list.