### PR TITLE
Add new model with _oldRev for PUT document endpoints.

### DIFF
--- a/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
+++ b/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
@@ -407,7 +407,9 @@ namespace ArangoDBNetStandardTest.DocumentApi
 
             Assert.NotNull(response._rev);
             Assert.NotNull(updateResponse._rev);
+            Assert.NotNull(updateResponse._oldRev);
             Assert.NotEqual(response._rev, updateResponse._rev);
+            Assert.Equal(response._rev, updateResponse._oldRev);
         }
 
         [Fact]
@@ -526,11 +528,15 @@ namespace ArangoDBNetStandardTest.DocumentApi
 
             Assert.NotNull(response[0]._rev);
             Assert.NotNull(updateResponse[0]._rev);
+            Assert.NotNull(updateResponse[0]._oldRev);
             Assert.NotEqual(response[0]._rev, updateResponse[0]._rev);
+            Assert.Equal(response[0]._rev, updateResponse[0]._oldRev);
 
             Assert.NotNull(response[1]._rev);
             Assert.NotNull(updateResponse[1]._rev);
+            Assert.NotNull(updateResponse[1]._oldRev);
             Assert.NotEqual(response[1]._rev, updateResponse[1]._rev);
+            Assert.Equal(response[1]._rev, updateResponse[1]._oldRev);
         }
 
         [Fact]

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -107,7 +107,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="documents"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PostDocumentsResponse<T>> PutDocumentsAsync<T>(string collectionName, IList<T> documents, PutDocumentsQuery query = null)
+        public async Task<PutDocumentsResponse<T>> PutDocumentsAsync<T>(
+            string collectionName,
+            IList<T> documents,
+            PutDocumentsQuery query = null)
         {
             string uri = _docApiPath + "/" + WebUtility.UrlEncode(collectionName);
             if (query != null)
@@ -120,7 +123,7 @@ namespace ArangoDBNetStandard.DocumentApi
                 if (response.IsSuccessStatusCode)
                 {
                     var stream = await response.Content.ReadAsStreamAsync();
-                    return DeserializeJsonFromStream<PostDocumentsResponse<T>>(stream);
+                    return DeserializeJsonFromStream<PutDocumentsResponse<T>>(stream);
                 }
                 throw await GetApiErrorException(response);
             }
@@ -137,7 +140,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="doc"></param>
         /// <param name="opts"></param>
         /// <returns></returns>
-        public async Task<PostDocumentResponse<T>> PutDocumentAsync<T>(
+        public async Task<PutDocumentResponse<T>> PutDocumentAsync<T>(
             string documentId,
             T doc,
             PutDocumentQuery opts = null)
@@ -154,7 +157,7 @@ namespace ArangoDBNetStandard.DocumentApi
                 if (response.IsSuccessStatusCode)
                 {
                     var stream = await response.Content.ReadAsStreamAsync();
-                    return DeserializeJsonFromStream<PostDocumentResponse<T>>(stream);
+                    return DeserializeJsonFromStream<PutDocumentResponse<T>>(stream);
                 }
                 throw await GetApiErrorException(response);
             }

--- a/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
@@ -44,7 +44,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="documents"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        Task<PostDocumentsResponse<T>> PutDocumentsAsync<T>(
+        Task<PutDocumentsResponse<T>> PutDocumentsAsync<T>(
            string collectionName,
            IList<T> documents,
            PutDocumentsQuery query = null);
@@ -60,7 +60,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="doc"></param>
         /// <param name="opts"></param>
         /// <returns></returns>
-        Task<PostDocumentResponse<T>> PutDocumentAsync<T>(
+        Task<PutDocumentResponse<T>> PutDocumentAsync<T>(
             string documentId,
             T doc,
             PutDocumentQuery opts = null);

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentResponse.cs
@@ -1,17 +1,26 @@
 ﻿namespace ArangoDBNetStandard.DocumentApi.Models
 {
-    public class PatchDocumentResponse<U>
+    /// <summary>
+    /// Represents a response returned when updating a single document.
+    /// </summary>
+    /// <typeparam name="U">The type of the deserialized new/old document object when requested.</typeparam>
+    public class PatchDocumentResponse<U> : DocumentBase
     {
+        /// <summary>
+        /// Deserialized copy of the new document object. This will only be present if requested with the
+        /// <see cref="PatchDocumentQuery.ReturnNew"/> option.
+        /// </summary>
         public U New { get; set; }
 
+        /// <summary>
+        /// Deserialized copy of the old document object. This will only be present if requested with the
+        /// <see cref="PatchDocumentQuery.ReturnOld"/> option.
+        /// </summary>
         public U Old { get; set; }
 
-        public string _key { get; set; }
-
-        public string _rev { get; set; }
-
+        /// <summary>
+        /// Contains the revision of the old (now updated) document.
+        /// </summary>
         public string _oldRev { get; set; }
-
-        public string _id { get; set; }
     }
 }

--- a/arangodb-net-standard/DocumentApi/Models/PutDocumentResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PutDocumentResponse.cs
@@ -1,0 +1,26 @@
+﻿namespace ArangoDBNetStandard.DocumentApi.Models
+{
+    /// <summary>
+    /// Represents a response returned when replacing a single document.
+    /// </summary>
+    /// <typeparam name="T">The type of the deserialized new/old document object when requested.</typeparam>
+    public class PutDocumentResponse<T> : DocumentBase
+    {
+        /// <summary>
+        /// Contains the revision of the old (now replaced) document.
+        /// </summary>
+        public string _oldRev { get; set; }
+
+        /// <summary>
+        /// Deserialized copy of the new document object. This will only be present if requested with the
+        /// <see cref="PutDocumentQuery.ReturnNew"/> option.
+        /// </summary>
+        public T New { get; set; }
+
+        /// <summary>
+        /// Deserialized copy of the old document object. This will only be present if requested with the
+        /// <see cref="PutDocumentQuery.ReturnOld"/> option.
+        /// </summary>
+        public T Old { get; set; }
+    }
+}

--- a/arangodb-net-standard/DocumentApi/Models/PutDocumentsDocumentResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PutDocumentsDocumentResponse.cs
@@ -1,0 +1,24 @@
+﻿namespace ArangoDBNetStandard.DocumentApi.Models
+{
+    /// <summary>
+    /// Represents the response for one document when replacing multiple document.
+    /// </summary>
+    /// <typeparam name="T">The type of the deserialized new/old document object when requested.</typeparam>
+    public class PutDocumentsDocumentResponse<T> : PutDocumentResponse<T>
+    {
+        /// <summary>
+        /// Indicates whether an error occurred.
+        /// </summary>
+        public bool Error { get; set; }
+
+        /// <summary>
+        /// Error message.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// ArangoDB error number.
+        /// </summary>
+        public int ErrorNum { get; set; }
+    }
+}

--- a/arangodb-net-standard/DocumentApi/Models/PutDocumentsResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PutDocumentsResponse.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.DocumentApi.Models
+{
+    /// <summary>
+    /// Represents the response returned when replacing multiple document.
+    /// </summary>
+    /// <typeparam name="T">The type of the deserialized new/old document object when requested.</typeparam>
+    public class PutDocumentsResponse<T> : List<PutDocumentsDocumentResponse<T>>
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="PutDocumentsResponse{T}"/>
+        /// with default values.
+        /// </summary>
+        public PutDocumentsResponse()
+        {
+        }
+
+        private PutDocumentsResponse(int capacity)
+            : base(capacity)
+        {
+        }
+
+        /// <summary>
+        /// Creates an empty response.
+        /// </summary>
+        /// <returns></returns>
+        public static PutDocumentsResponse<T> Empty()
+        {
+            return new PutDocumentsResponse<T>(0);
+        }
+    }
+}


### PR DESCRIPTION
fix #220

- Create a new response model for PUT document endpoints, in line with other endpoints
- Use the existing `DocumentBase` model when possible
- Update tests
- Add missing comments to other similar response models