### PR TITLE
Add support for maxRuntime cursor option.

### DIFF
--- a/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
+++ b/arangodb-net-standard.Test/CursorApi/CursorApiClientTest.cs
@@ -22,7 +22,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         {
             _cursorApi = fixture.ArangoDBClient.Cursor;
         }
-        
+
         [Fact]
         public async Task PostCursorAsync_ShouldSucceed()
         {
@@ -133,6 +133,21 @@ namespace ArangoDBNetStandardTest.CursorApi
         }
 
         [Fact]
+        public async Task PostCursorAsync_ShouldSucceed_WhenUsingOtherOptions()
+        {
+            var response = await _cursorApi.PostCursorAsync<MyModel>(
+                "FOR doc IN [{ myProperty: CONCAT('This is a ', @testString) }] LIMIT 1 RETURN doc",
+                new Dictionary<string, object> { ["testString"] = "robbery" },
+                new PostCursorOptions
+                {
+                    MaxRuntime = 10
+                });
+
+            Assert.Single(response.Result);
+            Assert.Equal("This is a robbery", response.Result.First().MyProperty);
+        }
+
+        [Fact]
         public async Task PostCursorAsync_ShouldThrow_WhenAqlIsNotValid()
         {
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
@@ -165,14 +180,14 @@ namespace ArangoDBNetStandardTest.CursorApi
             var nextResponse = await _cursorApi.PutCursorAsync<long>(response.Id);
             Assert.False(nextResponse.HasMore);
 
-            await Assert.ThrowsAsync<ApiErrorException>(async () => 
+            await Assert.ThrowsAsync<ApiErrorException>(async () =>
                 await _cursorApi.PutCursorAsync<long>(response.Id));
         }
 
         [Fact]
         public async Task PutCursorAsync_ShouldThrow_WhenCursorDoesNotExist()
         {
-            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () => 
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
                 await _cursorApi.PutCursorAsync<long>("nada"));
 
             Assert.NotNull(ex.ApiError.ErrorMessage);
@@ -183,7 +198,7 @@ namespace ArangoDBNetStandardTest.CursorApi
         [Fact]
         public async Task DeleteCursorAsync_ShouldThrow_WhenCursorDoesNotExist()
         {
-            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () => 
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
                 await _cursorApi.DeleteCursorAsync("nada"));
 
             Assert.NotNull(ex.ApiError.ErrorMessage);

--- a/arangodb-net-standard/CursorApi/Models/PostCursorBody.cs
+++ b/arangodb-net-standard/CursorApi/Models/PostCursorBody.cs
@@ -2,22 +2,64 @@
 
 namespace ArangoDBNetStandard.CursorApi.Models
 {
+    /// <summary>
+    /// Represents a request body for creating an AQL query cursor.
+    /// </summary>
     public class PostCursorBody
     {
+        /// <summary>
+        /// Contains the AQL query to be executed.
+        /// </summary>
         public string Query { get; set; }
 
+        /// <summary>
+        /// The bind parameters of the AQL query.
+        /// </summary>
         public Dictionary<string, object> BindVars { get; set; }
 
+        /// <summary>
+        /// Extra options for the AQL query.
+        /// </summary>
         public PostCursorOptions Options { get; set; }
 
+        /// <summary>
+        /// Whether the number of documents in the result set should be returned
+        /// in <see cref="CursorResponse{T}.Count"/>.
+        /// Calculating the “count” attribute might have a performance impact for some queries
+        /// so this option is turned off by default, and “count” is only returned when requested.
+        /// </summary>
         public bool? Count { get; set; }
 
+        /// <summary>
+        /// Maximum number of result documents to be transferred from the server
+        /// to the client in one roundtrip. If this attribute is not set,
+        /// a server-controlled default value will be used.
+        /// A value of 0 is disallowed.
+        /// </summary>
         public long? BatchSize { get; set; }
 
+        /// <summary>
+        /// Flag to determine whether the AQL query results cache shall be used.
+        /// If set to false, then any query cache lookup will be skipped for the query.
+        /// If set to true, it will lead to the query cache being checked for the query
+        /// if the query cache mode is either 'on' or 'demand'.
+        /// </summary>
         public bool? Cache { get; set; }
 
+        /// <summary>
+        /// The maximum number of memory (measured in bytes) that the query is allowed to use.
+        /// If set, then the query will fail with error “resource limit exceeded”
+        /// in case it allocates too much memory.
+        /// A value of 0 indicates that there is no memory limit.
+        /// </summary>
         public long? MemoryLimit { get; set; }
 
+        /// <summary>
+        /// The time-to-live for the cursor (in seconds).
+        /// The cursor will be removed on the server automatically after the specified amount of time.
+        /// This is useful to ensure garbage collection of cursors that are not fully fetched by clients.
+        /// If not set, a server-defined value will be used (default: 30 seconds).
+        /// </summary>
         public int? Ttl { get; set; }
     }
 

--- a/arangodb-net-standard/CursorApi/Models/PostCursorOptions.cs
+++ b/arangodb-net-standard/CursorApi/Models/PostCursorOptions.cs
@@ -1,8 +1,10 @@
 ﻿namespace ArangoDBNetStandard.CursorApi.Models
 {
+    /// <summary>
+    /// Represents extra options for the AQL query.
+    /// </summary>
     public class PostCursorOptions
     {
-
         /// <summary>
         /// If set to true and the query contains a LIMIT clause,
         /// then the result will have an extra attribute with the
@@ -81,6 +83,14 @@
         /// is 60.0 (seconds). When the max time has been reached the query will be stopped.
         /// </summary>
         public double? SatelliteSyncWait { get; set; }
+
+        /// <summary>
+        /// The query has to be executed within the given runtime or it will be killed.
+        /// The value is specified in seconds. A value of 0 means no timeout will be enforced.
+        /// The default value is 0 (no timeout).
+        /// Available in ArangoDB 3.6 onwards.
+        /// </summary>
+        public double? MaxRuntime { get; set; }
 
         /// <summary>
         /// Transaction size limit in bytes. Honored by the RocksDB storage engine only.


### PR DESCRIPTION
#246

https://www.arangodb.com/docs/stable/http/aql-query-cursor-accessing-cursors.html

I have tested that this new option works when provided. I used something like this:

```csharp
PostCursorAsync<object>("FOR i IN 1..1000000 RETURN { iteration: CONCAT("iteration ", i) }",
                new Dictionary<string, object> { },
                new PostCursorOptions
                {
                    MaxRuntime = 1
                })
```