### PR TITLE
Make client APIs extensible.

### DIFF
--- a/arangodb-net-standard/AqlFunctionApi/AqlFunctionApiClient.cs
+++ b/arangodb-net-standard/AqlFunctionApi/AqlFunctionApiClient.cs
@@ -12,9 +12,15 @@ namespace ArangoDBNetStandard.AqlFunctionApi
     /// </summary>
     public class AqlFunctionApiClient : ApiClientBase, IAqlFunctionApiClient
     {
-        private readonly IApiClientTransport _transport;
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
+        protected readonly IApiClientTransport _transport;
 
-        private readonly string _apiPath = "_api/aqlfunction";
+        /// <summary>
+        /// The root path of the API.
+        /// </summary>
+        protected readonly string _apiPath = "_api/aqlfunction";
 
         /// <summary>
         /// Create an instance of <see cref="AqlFunctionApiClient"/>
@@ -45,7 +51,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// </summary>
         /// <param name="body">The body of the request containing required properties.</param>
         /// <returns></returns>
-        public async Task<PostAqlFunctionResponse> PostAqlFunctionAsync(PostAqlFunctionBody body)
+        public virtual async Task<PostAqlFunctionResponse> PostAqlFunctionAsync(PostAqlFunctionBody body)
         {
             var content = GetContent(body, true, true);
 
@@ -67,7 +73,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// <param name="name">The name of the function or function group (namespace).</param>
         /// <param name="query">The query parameters of the request.</param>
         /// <returns></returns>
-        public async Task<DeleteAqlFunctionResponse> DeleteAqlFunctionAsync(
+        public virtual async Task<DeleteAqlFunctionResponse> DeleteAqlFunctionAsync(
             string name,
             DeleteAqlFunctionQuery query = null)
         {
@@ -93,7 +99,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// Get all registered AQL user functions.
         /// </summary>
         /// <returns></returns>
-        public async Task<GetAqlFunctionsResponse> GetAqlFunctionsAsync(GetAqlFunctionsQuery query = null)
+        public virtual async Task<GetAqlFunctionsResponse> GetAqlFunctionsAsync(GetAqlFunctionsQuery query = null)
         {
             string uri = _apiPath;
 

--- a/arangodb-net-standard/ArangoDBClient.cs
+++ b/arangodb-net-standard/ArangoDBClient.cs
@@ -19,13 +19,19 @@ namespace ArangoDBNetStandard
     /// </summary>
     public class ArangoDBClient : IDisposable
     {
-        private IApiClientTransport _transport;
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
+        protected IApiClientTransport _transport;
 
         /// <summary>
         /// AQL user functions management API.
         /// </summary>
-        public AqlFunctionApiClient AqlFunction { get; set; }
+        public AqlFunctionApiClient AqlFunction { get; private set; }
 
+        /// <summary>
+        /// Auth API
+        /// </summary>
         public AuthApiClient Auth { get; private set; }
 
         /// <summary>

--- a/arangodb-net-standard/AuthApi/AuthApiClient.cs
+++ b/arangodb-net-standard/AuthApi/AuthApiClient.cs
@@ -10,14 +10,28 @@ namespace ArangoDBNetStandard.AuthApi
     /// </summary>
     public class AuthApiClient : ApiClientBase, IAuthApiClient
     {
-        private IApiClientTransport _client;
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
+        protected IApiClientTransport _client;
 
+        /// <summary>
+        /// Create an instance of <see cref="AuthApiClient"/>
+        /// using the provided transport layer and the default JSON serialization.
+        /// </summary>
+        /// <param name="client"></param>
         public AuthApiClient(IApiClientTransport client)
             : base(new JsonNetApiClientSerialization())
         {
             _client = client;
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="AuthApiClient"/>
+        /// using the provided transport and serialization layers.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="serializer"></param>
         public AuthApiClient(IApiClientTransport client, IApiClientSerialization serializer)
             : base(serializer)
         {
@@ -30,7 +44,7 @@ namespace ArangoDBNetStandard.AuthApi
         /// <param name="username">The username of the user for whom to generate a JWT token.</param>
         /// <param name="password">The user's password.</param>
         /// <returns>Object containing the encoded JWT token value.</returns>
-        public async Task<JwtTokenResponse> GetJwtTokenAsync(string username, string password)
+        public virtual async Task<JwtTokenResponse> GetJwtTokenAsync(string username, string password)
         {
             return await GetJwtTokenAsync(new JwtTokenRequestBody
             {
@@ -44,7 +58,7 @@ namespace ArangoDBNetStandard.AuthApi
         /// </summary>
         /// <param name="body">Object containing username and password.</param>
         /// <returns>Object containing the encoded JWT token value.</returns>
-        public async Task<JwtTokenResponse> GetJwtTokenAsync(JwtTokenRequestBody body)
+        public virtual async Task<JwtTokenResponse> GetJwtTokenAsync(JwtTokenRequestBody body)
         {
             byte[] content = GetContent(body, true, false);
             using (var response = await _client.PostAsync("/_open/auth", content))

--- a/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
@@ -12,14 +12,21 @@ namespace ArangoDBNetStandard.CollectionApi
     /// </summary>
     public class CollectionApiClient : ApiClientBase, ICollectionApiClient
     {
-        private IApiClientTransport _transport;
-        private string _collectionApiPath = "_api/collection";
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
+        protected IApiClientTransport _transport;
+
+        /// <summary>
+        /// The root path of the API.
+        /// </summary>
+        protected string _collectionApiPath = "_api/collection";
 
         /// <summary>
         /// Creates an instance of <see cref="CollectionApiClient"/>
         /// using the provided transport layer and the default JSON serialization.
         /// </summary>
-        /// <param name="client"></param>
+        /// <param name="transport"></param>
         public CollectionApiClient(IApiClientTransport transport)
             : base(new JsonNetApiClientSerialization())
         {
@@ -38,7 +45,7 @@ namespace ArangoDBNetStandard.CollectionApi
             _transport = transport;
         }
 
-        public async Task<PostCollectionResponse> PostCollectionAsync(PostCollectionBody body, PostCollectionQuery options = null)
+        public virtual async Task<PostCollectionResponse> PostCollectionAsync(PostCollectionBody body, PostCollectionQuery options = null)
         {
             string uriString = _collectionApiPath;
             if (options != null)
@@ -57,7 +64,7 @@ namespace ArangoDBNetStandard.CollectionApi
             }
         }
 
-        public async Task<DeleteCollectionResponse> DeleteCollectionAsync(string collectionName)
+        public virtual async Task<DeleteCollectionResponse> DeleteCollectionAsync(string collectionName)
         {
             using (var response = await _transport.DeleteAsync(_collectionApiPath + "/" + WebUtility.UrlEncode(collectionName)))
             {
@@ -76,7 +83,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="collectionName"></param>
         /// <returns></returns>
-        public async Task<TruncateCollectionResponse> TruncateCollectionAsync(string collectionName)
+        public virtual async Task<TruncateCollectionResponse> TruncateCollectionAsync(string collectionName)
         {
             using (var response = await _transport.PutAsync(
                 _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/truncate",
@@ -97,7 +104,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="collectionName"></param>
         /// <returns></returns>
-        public async Task<GetCollectionCountResponse> GetCollectionCountAsync(string collectionName)
+        public virtual async Task<GetCollectionCountResponse> GetCollectionCountAsync(string collectionName)
         {
             using (var response = await _transport.GetAsync(_collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/count"))
             {
@@ -116,7 +123,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public async Task<GetCollectionsResponse> GetCollectionsAsync(GetCollectionsQuery query = null)
+        public virtual async Task<GetCollectionsResponse> GetCollectionsAsync(GetCollectionsQuery query = null)
         {
             string uriString = _collectionApiPath;
             if (query != null)
@@ -159,7 +166,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="options"></param>
         /// <returns></returns>
-        public async Task<GetCollectionPropertiesResponse> GetCollectionPropertiesAsync(string collectionName)
+        public virtual async Task<GetCollectionPropertiesResponse> GetCollectionPropertiesAsync(string collectionName)
         {
             using (var response = await _transport.GetAsync(_collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/properties"))
             {
@@ -177,9 +184,9 @@ namespace ArangoDBNetStandard.CollectionApi
         /// PUT /_api/collection/{collection-name}/rename
         /// </summary>
         /// <param name="collectionName"></param>
-        /// <param name="request"></param>
+        /// <param name="body"></param>
         /// <returns></returns>
-        public async Task<RenameCollectionResponse> RenameCollectionAsync(string collectionName, RenameCollectionBody body)
+        public virtual async Task<RenameCollectionResponse> RenameCollectionAsync(string collectionName, RenameCollectionBody body)
         {
             var content = GetContent(body, true, false);
             using (var response = await _transport.PutAsync(_collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/rename", content))
@@ -200,7 +207,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// </summary>
         /// <param name="collectionName">Name of the collection</param>
         /// <returns></returns>
-        public async Task<GetCollectionRevisionResponse> GetCollectionRevisionAsync(string collectionName)
+        public virtual async Task<GetCollectionRevisionResponse> GetCollectionRevisionAsync(string collectionName)
         {
             using (var response = await _transport.GetAsync(_collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/revision"))
             {
@@ -220,7 +227,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <param name="collectionName"></param>
         /// <param name="body"></param>
         /// <returns></returns>
-        public async Task<PutCollectionPropertyResponse> PutCollectionPropertyAsync(string collectionName, PutCollectionPropertyBody body)
+        public virtual async Task<PutCollectionPropertyResponse> PutCollectionPropertyAsync(string collectionName, PutCollectionPropertyBody body)
         {
             var content = GetContent(body, true, true);
             using (var response = await _transport.PutAsync(_collectionApiPath + "/" + collectionName + "/properties", content))
@@ -238,9 +245,9 @@ namespace ArangoDBNetStandard.CollectionApi
         /// Contains the number of documents and additional statistical information about the collection.
         /// GET/_api/collection/{collection-name}/figures
         /// </summary>
-        /// <param name="options"></param>
+        /// <param name="collectionName"></param>
         /// <returns></returns>
-        public async Task<GetCollectionFiguresResponse> GetCollectionFiguresAsync(string collectionName)
+        public virtual async Task<GetCollectionFiguresResponse> GetCollectionFiguresAsync(string collectionName)
         {
             using (var response = await _transport.GetAsync(_collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/figures"))
             {

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -12,8 +12,15 @@ namespace ArangoDBNetStandard.CursorApi
     /// </summary>
     public class CursorApiClient : ApiClientBase, ICursorApiClient
     {
-        private readonly string _cursorApiPath = "_api/cursor";
-        private IApiClientTransport _client;
+        /// <summary>
+        /// The root path of the API.
+        /// </summary>
+        protected readonly string _cursorApiPath = "_api/cursor";
+
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
+        protected IApiClientTransport _client;
 
         /// <summary>
         /// Creates an instance of <see cref="CursorApiClient"/>
@@ -51,7 +58,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <param name="memoryLimit"></param>
         /// <param name="ttl"></param>
         /// <returns></returns>
-        public async Task<CursorResponse<T>> PostCursorAsync<T>(
+        public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(
                 string query,
                 Dictionary<string, object> bindVars = null,
                 PostCursorOptions options = null,
@@ -79,7 +86,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// </summary>
         /// <param name="postCursorBody">Object encapsulating options and parameters of the query.</param>
         /// <returns></returns>
-        public async Task<CursorResponse<T>> PostCursorAsync<T>(PostCursorBody postCursorBody)
+        public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(PostCursorBody postCursorBody)
         {
             var content = GetContent(postCursorBody, true, true);
             using (var response = await _client.PostAsync(_cursorApiPath, content))
@@ -99,7 +106,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// </summary>
         /// <param name="cursorId">The id of the cursor to delete.</param>
         /// <returns></returns>
-        public async Task<DeleteCursorResponse> DeleteCursorAsync(string cursorId)
+        public virtual async Task<DeleteCursorResponse> DeleteCursorAsync(string cursorId)
         {
             using (var response = await _client.DeleteAsync(_cursorApiPath + "/" + WebUtility.UrlEncode(cursorId)))
             {
@@ -118,7 +125,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <typeparam name="T">Result type to deserialize to</typeparam>
         /// <param name="cursorId">ID of the existing query cursor.</param>
         /// <returns></returns>
-        public async Task<PutCursorResponse<T>> PutCursorAsync<T>(string cursorId)
+        public virtual async Task<PutCursorResponse<T>> PutCursorAsync<T>(string cursorId)
         {
             string uri = _cursorApiPath + "/" + WebUtility.UrlEncode(cursorId);
             using (var response = await _client.PutAsync(uri, new byte[0]))

--- a/arangodb-net-standard/DatabaseApi/DatabaseApiClient.cs
+++ b/arangodb-net-standard/DatabaseApi/DatabaseApiClient.cs
@@ -6,9 +6,20 @@ using System.Threading.Tasks;
 
 namespace ArangoDBNetStandard.DatabaseApi
 {
+    /// <summary>
+    /// A client for interacting with ArangoDB Databases endpoints,
+    /// implementing <see cref="IDatabaseApiClient"/>.
+    /// </summary>
     public class DatabaseApiClient : ApiClientBase, IDatabaseApiClient
     {
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
         private IApiClientTransport _client;
+
+        /// <summary>
+        /// The root path of the API.
+        /// </summary>
         private readonly string _databaseApiPath = "_api/database";
 
         /// <summary>
@@ -40,7 +51,7 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// </summary>
         /// <param name="request">The parameters required by this endpoint.</param>
         /// <returns></returns>
-        public async Task<PostDatabaseResponse> PostDatabaseAsync(PostDatabaseBody request)
+        public virtual async Task<PostDatabaseResponse> PostDatabaseAsync(PostDatabaseBody request)
         {
             var content = GetContent(request, true, true);
             using (var response = await _client.PostAsync(_databaseApiPath, content))
@@ -61,7 +72,7 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// </summary>
         /// <param name="databaseName"></param>
         /// <returns></returns>
-        public async Task<DeleteDatabaseResponse> DeleteDatabaseAsync(string databaseName)
+        public virtual async Task<DeleteDatabaseResponse> DeleteDatabaseAsync(string databaseName)
         {
             using (var response = await _client.DeleteAsync(_databaseApiPath + "/" + WebUtility.UrlEncode(databaseName)))
             {
@@ -83,7 +94,7 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// available for the current user.
         /// </remarks>
         /// <returns></returns>
-        public async Task<GetDatabasesResponse> GetDatabasesAsync()
+        public virtual async Task<GetDatabasesResponse> GetDatabasesAsync()
         {
             using (var response = await _client.GetAsync(_databaseApiPath))
             {
@@ -100,7 +111,7 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// Retrieves the list of all databases the current user can access.
         /// </summary>
         /// <returns></returns>
-        public async Task<GetDatabasesResponse> GetUserDatabasesAsync()
+        public virtual async Task<GetDatabasesResponse> GetUserDatabasesAsync()
         {
             using (var response = await _client.GetAsync(_databaseApiPath + "/user"))
             {
@@ -117,7 +128,7 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// Retrieves information about the current database.
         /// </summary>
         /// <returns></returns>
-        public async Task<GetCurrentDatabaseInfoResponse> GetCurrentDatabaseInfoAsync()
+        public virtual async Task<GetCurrentDatabaseInfoResponse> GetCurrentDatabaseInfoAsync()
         {
             using (var response = await _client.GetAsync(_databaseApiPath + "/current"))
             {

--- a/arangodb-net-standard/DatabaseApi/DatabaseApiClient.cs
+++ b/arangodb-net-standard/DatabaseApi/DatabaseApiClient.cs
@@ -15,12 +15,12 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// <summary>
         /// The transport client used to communicate with the ArangoDB host.
         /// </summary>
-        private IApiClientTransport _client;
+        protected IApiClientTransport _client;
 
         /// <summary>
         /// The root path of the API.
         /// </summary>
-        private readonly string _databaseApiPath = "_api/database";
+        protected readonly string _databaseApiPath = "_api/database";
 
         /// <summary>
         /// Creates an instance of <see cref="DatabaseApiClient"/>

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -12,7 +12,14 @@ namespace ArangoDBNetStandard.DocumentApi
     /// </summary>
     public class DocumentApiClient : ApiClientBase, IDocumentApiClient
     {
+        /// <summary>
+        /// The root path of the API.
+        /// </summary>
         private readonly string _docApiPath = "_api/document";
+
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
         private IApiClientTransport _client;
 
         /// <summary>
@@ -46,7 +53,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="document"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PostDocumentResponse<T>> PostDocumentAsync<T>(string collectionName, T document, PostDocumentsQuery query = null)
+        public virtual async Task<PostDocumentResponse<T>> PostDocumentAsync<T>(
+            string collectionName,
+            T document,
+            PostDocumentsQuery query = null)
         {
             string uriString = _docApiPath + "/" + WebUtility.UrlEncode(collectionName);
             if (query != null)
@@ -73,7 +83,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="documents"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PostDocumentsResponse<T>> PostDocumentsAsync<T>(string collectionName, IList<T> documents, PostDocumentsQuery query = null)
+        public virtual async Task<PostDocumentsResponse<T>> PostDocumentsAsync<T>(
+            string collectionName,
+            IList<T> documents,
+            PostDocumentsQuery query = null)
         {
             string uriString = _docApiPath + "/" + WebUtility.UrlEncode(collectionName);
             if (query != null)
@@ -107,7 +120,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="documents"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PutDocumentsResponse<T>> PutDocumentsAsync<T>(
+        public virtual async Task<PutDocumentsResponse<T>> PutDocumentsAsync<T>(
             string collectionName,
             IList<T> documents,
             PutDocumentsQuery query = null)
@@ -139,7 +152,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="doc"></param>
         /// <param name="opts"></param>
         /// <returns></returns>
-        public async Task<PutDocumentResponse<T>> PutDocumentAsync<T>(
+        public virtual async Task<PutDocumentResponse<T>> PutDocumentAsync<T>(
             string documentId,
             T doc,
             PutDocumentQuery opts = null)
@@ -173,13 +186,16 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="doc"></param>
         /// <param name="opts"></param>
         /// <returns></returns>
-        public Task<PutDocumentResponse<T>> PutDocumentAsync<T>(
+        public virtual Task<PutDocumentResponse<T>> PutDocumentAsync<T>(
             string collectionName,
             string documentKey,
             T doc,
             PutDocumentQuery opts = null)
         {
-            return PutDocumentAsync<T>($"{WebUtility.UrlEncode(collectionName)}/{WebUtility.UrlEncode(documentKey)}", doc, opts);
+            return PutDocumentAsync<T>(
+                $"{WebUtility.UrlEncode(collectionName)}/{WebUtility.UrlEncode(documentKey)}",
+                doc,
+                opts);
         }
 
         /// <summary>
@@ -189,9 +205,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="collectionName"></param>
         /// <param name="documentKey"></param>
         /// <returns></returns>
-        public async Task<T> GetDocumentAsync<T>(string collectionName, string documentKey)
+        public virtual async Task<T> GetDocumentAsync<T>(string collectionName, string documentKey)
         {
-            return await GetDocumentAsync<T>($"{WebUtility.UrlEncode(collectionName)}/{WebUtility.UrlEncode(documentKey)}");
+            return await GetDocumentAsync<T>(
+                $"{WebUtility.UrlEncode(collectionName)}/{WebUtility.UrlEncode(documentKey)}");
         }
 
         /// <summary>
@@ -200,7 +217,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <typeparam name="T"></typeparam>
         /// <param name="documentId"></param>
         /// <returns></returns>
-        public async Task<T> GetDocumentAsync<T>(string documentId)
+        public virtual async Task<T> GetDocumentAsync<T>(string documentId)
         {
             ValidateDocumentId(documentId);
             var response = await _client.GetAsync(_docApiPath + "/" + documentId);
@@ -220,7 +237,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="collectionName">Collection name</param>
         /// <param name="selectors">Document keys to fetch documents for</param>
         /// <returns></returns>
-        public async Task<List<T>> GetDocumentsAsync<T>(string collectionName, IList<string> selectors)
+        public virtual async Task<List<T>> GetDocumentsAsync<T>(string collectionName, IList<string> selectors)
         {
             string uri = $"{_docApiPath}/{WebUtility.UrlEncode(collectionName)}?onlyget=true";
 
@@ -251,7 +268,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="documentKey"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteDocumentResponse<object>> DeleteDocumentAsync(
+        public virtual async Task<DeleteDocumentResponse<object>> DeleteDocumentAsync(
             string collectionName,
             string documentKey,
             DeleteDocumentQuery query = null)
@@ -273,7 +290,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="documentId"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteDocumentResponse<object>> DeleteDocumentAsync(
+        public virtual async Task<DeleteDocumentResponse<object>> DeleteDocumentAsync(
             string documentId,
             DeleteDocumentQuery query = null)
         {
@@ -288,7 +305,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="documentKey"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(
+        public virtual async Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(
             string collectionName,
             string documentKey,
             DeleteDocumentQuery query = null)
@@ -304,7 +321,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="documentId"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(
+        public virtual async Task<DeleteDocumentResponse<T>> DeleteDocumentAsync<T>(
             string documentId,
             DeleteDocumentQuery query = null)
         {
@@ -332,15 +349,18 @@ namespace ArangoDBNetStandard.DocumentApi
         /// </summary>
         /// <remarks>
         /// This method overload is provided as a convenience when the client does not care about the type of <see cref="DeleteDocumentResponse{T}.Old"/>
-        /// in the returned <see cref="DeleteDocumentsResponse{object}"/>. These will be <see cref="null"/> when 
-        /// <see cref="DeleteDocumentsQuery.ReturnOld"/> is either <see cref="false"/> or not set, so this overload is useful in the default case 
+        /// in the returned <see cref="DeleteDocumentsResponse{T}"/>. These will be <c>null</c> when 
+        /// <see cref="DeleteDocumentsQuery.ReturnOld"/> is either <c>false</c> or not set, so this overload is useful in the default case 
         /// when deleting documents.
         /// </remarks>
         /// <param name="collectionName"></param>
         /// <param name="selectors"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteDocumentsResponse<object>> DeleteDocumentsAsync(string collectionName, IList<string> selectors, DeleteDocumentsQuery query = null)
+        public virtual async Task<DeleteDocumentsResponse<object>> DeleteDocumentsAsync(
+            string collectionName,
+            IList<string> selectors,
+            DeleteDocumentsQuery query = null)
         {
             return await DeleteDocumentsAsync<object>(collectionName, selectors, query);
         }
@@ -354,7 +374,10 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="selectors"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteDocumentsResponse<T>> DeleteDocumentsAsync<T>(string collectionName, IList<string> selectors, DeleteDocumentsQuery query = null)
+        public virtual async Task<DeleteDocumentsResponse<T>> DeleteDocumentsAsync<T>(
+            string collectionName,
+            IList<string> selectors,
+            DeleteDocumentsQuery query = null)
         {
             string uri = _docApiPath + "/" + WebUtility.UrlEncode(collectionName);
             if (query != null)
@@ -404,7 +427,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="patches"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<IList<PatchDocumentsResponse<U>>> PatchDocumentsAsync<T, U>(
+        public virtual async Task<IList<PatchDocumentsResponse<U>>> PatchDocumentsAsync<T, U>(
             string collectionName,
             IList<T> patches,
             PatchDocumentsQuery query = null)
@@ -444,7 +467,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="body"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PatchDocumentResponse<U>> PatchDocumentAsync<T, U>(
+        public virtual async Task<PatchDocumentResponse<U>> PatchDocumentAsync<T, U>(
             string collectionName,
             string documentKey,
             T body,
@@ -473,7 +496,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="body"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PatchDocumentResponse<U>> PatchDocumentAsync<T, U>(
+        public virtual async Task<PatchDocumentResponse<U>> PatchDocumentAsync<T, U>(
             string documentId,
             T body,
             PatchDocumentQuery query = null)
@@ -512,12 +535,14 @@ namespace ArangoDBNetStandard.DocumentApi
         /// 412: is returned if an “If-Match” header is given and the found document has a different version. The response will also contain the found document’s current revision in the Etag header.
         /// </remarks>
         /// <returns></returns>
-        public async Task<HeadDocumentResponse> HeadDocumentAsync(
+        public virtual async Task<HeadDocumentResponse> HeadDocumentAsync(
             string collectionName,
             string documentKey,
             HeadDocumentHeader headers = null)
         {
-            return await HeadDocumentAsync($"{WebUtility.UrlEncode(collectionName)}/{WebUtility.UrlEncode(documentKey)}", headers);
+            return await HeadDocumentAsync(
+                $"{WebUtility.UrlEncode(collectionName)}/{WebUtility.UrlEncode(documentKey)}",
+                headers);
         }
 
         /// <summary>
@@ -528,7 +553,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// </summary>
         /// <param name="documentId"></param>
         /// <param name="headers">Object containing a dictionary of Header keys and values</param>
-        /// <exception cref="ArgumentException">Document ID is invalid.</exception>
+        /// <exception cref="System.ArgumentException">Document ID is invalid.</exception>
         /// <remarks>
         /// 200: is returned if the document was found. 
         /// 304: is returned if the “If-None-Match” header is given and the document has the same version. 
@@ -536,7 +561,9 @@ namespace ArangoDBNetStandard.DocumentApi
         /// 412: is returned if an “If-Match” header is given and the found document has a different version. The response will also contain the found document’s current revision in the Etag header.
         /// </remarks>
         /// <returns></returns>
-        public async Task<HeadDocumentResponse> HeadDocumentAsync(string documentId, HeadDocumentHeader headers = null)
+        public virtual async Task<HeadDocumentResponse> HeadDocumentAsync(
+            string documentId,
+            HeadDocumentHeader headers = null)
         {
             ValidateDocumentId(documentId);
             string uri = _docApiPath + "/" + documentId;

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -15,12 +15,12 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <summary>
         /// The root path of the API.
         /// </summary>
-        private readonly string _docApiPath = "_api/document";
+        protected readonly string _docApiPath = "_api/document";
 
         /// <summary>
         /// The transport client used to communicate with the ArangoDB host.
         /// </summary>
-        private IApiClientTransport _client;
+        protected IApiClientTransport _client;
 
         /// <summary>
         /// Creates an instance of <see cref="DocumentApiClient"/>

--- a/arangodb-net-standard/GraphApi/GraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/GraphApiClient.cs
@@ -6,9 +6,20 @@ using System.Threading.Tasks;
 
 namespace ArangoDBNetStandard.GraphApi
 {
+    /// <summary>
+    /// A client for interacting with ArangoDB Graphs endpoints,
+    /// implementing <see cref="IGraphApiClient"/>.
+    /// </summary>
     public class GraphApiClient : ApiClientBase, IGraphApiClient
     {
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
         private IApiClientTransport _transport;
+
+        /// <summary>
+        /// The root path of the API.
+        /// </summary>
         private readonly string _graphApiPath = "_api/gharial";
 
         /// <summary>
@@ -39,8 +50,9 @@ namespace ArangoDBNetStandard.GraphApi
         /// POST /_api/gharial
         /// </summary>
         /// <param name="postGraphBody">The information of the graph to create.</param>
+        /// <param name="query">Optional query parameters of the request.</param>
         /// <returns></returns>
-        public async Task<PostGraphResponse> PostGraphAsync(
+        public virtual async Task<PostGraphResponse> PostGraphAsync(
             PostGraphBody postGraphBody,
             PostGraphQuery query = null)
         {
@@ -73,7 +85,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// in ArangoDB 4.5.2 and below, in which case you can use <see cref="GraphResult._key"/> instead.
         /// </remarks>
         /// <returns></returns>
-        public async Task<GetGraphsResponse> GetGraphsAsync()
+        public virtual async Task<GetGraphsResponse> GetGraphsAsync()
         {
             using (var response = await _transport.GetAsync(_graphApiPath))
             {
@@ -95,7 +107,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName"></param>
         /// <param name="body"></param>
         /// <returns></returns>
-        public async Task<DeleteGraphResponse> DeleteGraphAsync(string graphName, DeleteGraphQuery query = null)
+        public virtual async Task<DeleteGraphResponse> DeleteGraphAsync(string graphName, DeleteGraphQuery query = null)
         {
             string uriString = _graphApiPath + "/" + WebUtility.UrlEncode(graphName);
             if (query != null)
@@ -120,7 +132,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// </summary>
         /// <param name="graphName"></param>
         /// <returns></returns>
-        public async Task<GetGraphResponse> GetGraphAsync(string graphName)
+        public virtual async Task<GetGraphResponse> GetGraphAsync(string graphName)
         {
             using (var response = await _transport.GetAsync(_graphApiPath + "/" + WebUtility.UrlEncode(graphName)))
             {
@@ -137,9 +149,9 @@ namespace ArangoDBNetStandard.GraphApi
         /// Lists all vertex collections within the given graph.
         /// GET /_api/gharial/{graph}/vertex
         /// </summary>
-        /// <param name="graph">The name of the graph.</param>
+        /// <param name="graphName">The name of the graph.</param>
         /// <returns></returns>
-        public async Task<GetVertexCollectionsResponse> GetVertexCollectionsAsync(string graphName)
+        public virtual async Task<GetVertexCollectionsResponse> GetVertexCollectionsAsync(string graphName)
         {
             using (var response = await _transport.GetAsync(_graphApiPath + '/' + WebUtility.UrlEncode(graphName) + "/vertex"))
             {
@@ -158,7 +170,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// </summary>
         /// <param name="graphName"></param>
         /// <returns></returns>
-        public async Task<GetEdgeCollectionsResponse> GetEdgeCollectionsAsync(string graphName)
+        public virtual async Task<GetEdgeCollectionsResponse> GetEdgeCollectionsAsync(string graphName)
         {
             using (var response = await _transport.GetAsync(_graphApiPath + "/" + WebUtility.UrlEncode(graphName) + "/edge"))
             {
@@ -184,7 +196,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="body">The information of the edge definition.</param>
         /// <returns></returns>
-        public async Task<PostEdgeDefinitionResponse> PostEdgeDefinitionAsync(
+        public virtual async Task<PostEdgeDefinitionResponse> PostEdgeDefinitionAsync(
             string graphName,
             PostEdgeDefinitionBody body)
         {
@@ -211,7 +223,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="body">The information of the vertex collection.</param>
         /// <returns></returns>
-        public async Task<PostVertexCollectionResponse> PostVertexCollectionAsync(
+        public virtual async Task<PostVertexCollectionResponse> PostVertexCollectionAsync(
             string graphName,
             PostVertexCollectionBody body)
         {
@@ -240,7 +252,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="vertex"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PostVertexResponse<T>> PostVertexAsync<T>(
+        public virtual async Task<PostVertexResponse<T>> PostVertexAsync<T>(
             string graphName,
             string collectionName,
             T vertex,
@@ -274,7 +286,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteEdgeDefinitionResponse> DeleteEdgeDefinitionAsync(
+        public virtual async Task<DeleteEdgeDefinitionResponse> DeleteEdgeDefinitionAsync(
             string graphName,
             string collectionName,
             DeleteEdgeDefinitionQuery query = null)
@@ -307,7 +319,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="collectionName"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteVertexCollectionResponse> DeleteVertexCollectionAsync(
+        public virtual async Task<DeleteVertexCollectionResponse> DeleteVertexCollectionAsync(
             string graphName,
             string collectionName,
             DeleteVertexCollectionQuery query = null)
@@ -342,8 +354,9 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="graphName">The name of the graph.</param>
         /// <param name="collectionName">The name of the edge collection the edge belongs to.</param>
         /// <param name="edge">The edge to create.</param>
+        /// <param name="query">Optional query parameters of the request.</param>
         /// <returns></returns>
-        public async Task<PostEdgeResponse<T>> PostEdgeAsync<T>(
+        public virtual async Task<PostEdgeResponse<T>> PostEdgeAsync<T>(
             string graphName,
             string collectionName,
             T edge,
@@ -379,7 +392,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="edgeKey">The _key attribute of the edge.</param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public Task<GetEdgeResponse<T>> GetEdgeAsync<T>(
+        public virtual Task<GetEdgeResponse<T>> GetEdgeAsync<T>(
             string graphName,
             string collectionName,
             string edgeKey,
@@ -400,7 +413,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="edgeHandle">The document-handle of the edge document.</param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<GetEdgeResponse<T>> GetEdgeAsync<T>(
+        public virtual async Task<GetEdgeResponse<T>> GetEdgeAsync<T>(
             string graphName,
             string edgeHandle,
             GetEdgeQuery query = null)
@@ -435,7 +448,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="edgeKey">The _key attribute of the edge.</param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteEdgeResponse<T>> DeleteEdgeAsync<T>(
+        public virtual async Task<DeleteEdgeResponse<T>> DeleteEdgeAsync<T>(
             string graphName,
             string collectionName,
             string edgeKey,
@@ -466,7 +479,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="vertexKey"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<GetVertexResponse<T>> GetVertexAsync<T>(
+        public virtual async Task<GetVertexResponse<T>> GetVertexAsync<T>(
             string graphName,
             string collectionName,
             string vertexKey,
@@ -498,7 +511,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="vertexKey"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<DeleteVertexResponse<T>> DeleteVertexAsync<T>(
+        public virtual async Task<DeleteVertexResponse<T>> DeleteVertexAsync<T>(
             string graphName,
             string collectionName,
             string vertexKey,
@@ -536,7 +549,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="body"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PatchVertexResponse<U>> PatchVertexAsync<T, U>(
+        public virtual async Task<PatchVertexResponse<U>> PatchVertexAsync<T, U>(
             string graphName,
             string collectionName,
             string vertexKey,
@@ -572,7 +585,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="edge"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PutEdgeResponse<T>> PutEdgeAsync<T>(
+        public virtual async Task<PutEdgeResponse<T>> PutEdgeAsync<T>(
             string graphName,
             string collectionName,
             string edgeKey,
@@ -609,7 +622,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="body"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PutEdgeDefinitionResponse> PutEdgeDefinitionAsync(
+        public virtual async Task<PutEdgeDefinitionResponse> PutEdgeDefinitionAsync(
             string graphName,
             string collectionName,
             PutEdgeDefinitionBody body,
@@ -647,7 +660,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="edge"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PatchEdgeResponse<T>> PatchEdgeAsync<T, U>(
+        public virtual async Task<PatchEdgeResponse<T>> PatchEdgeAsync<T, U>(
             string graphName,
             string collectionName,
             string edgeKey,
@@ -686,7 +699,7 @@ namespace ArangoDBNetStandard.GraphApi
         /// <param name="vertex"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public async Task<PutVertexResponse<T>> PutVertexAsync<T>(
+        public virtual async Task<PutVertexResponse<T>> PutVertexAsync<T>(
             string graphName,
             string collectionName,
             string key,

--- a/arangodb-net-standard/GraphApi/GraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/GraphApiClient.cs
@@ -15,12 +15,12 @@ namespace ArangoDBNetStandard.GraphApi
         /// <summary>
         /// The transport client used to communicate with the ArangoDB host.
         /// </summary>
-        private IApiClientTransport _transport;
+        protected IApiClientTransport _transport;
 
         /// <summary>
         /// The root path of the API.
         /// </summary>
-        private readonly string _graphApiPath = "_api/gharial";
+        protected readonly string _graphApiPath = "_api/gharial";
 
         /// <summary>
         /// Create an instance of <see cref="GraphApiClient"/>

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -13,12 +13,12 @@ namespace ArangoDBNetStandard.TransactionApi
         /// <summary>
         /// The transport client used to communicate with the ArangoDB host.
         /// </summary>
-        private IApiClientTransport _client;
+        protected IApiClientTransport _client;
 
         /// <summary>
         /// The root path of the API.
         /// </summary>
-        private readonly string _transactionApiPath = "_api/transaction";
+        protected readonly string _transactionApiPath = "_api/transaction";
 
         /// <summary>
         /// Create an instance of <see cref="TransactionApiClient"/>

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -10,7 +10,14 @@ namespace ArangoDBNetStandard.TransactionApi
     /// </summary>
     public class TransactionApiClient : ApiClientBase, ITransactionApiClient
     {
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
         private IApiClientTransport _client;
+
+        /// <summary>
+        /// The root path of the API.
+        /// </summary>
         private readonly string _transactionApiPath = "_api/transaction";
 
         /// <summary>
@@ -42,7 +49,8 @@ namespace ArangoDBNetStandard.TransactionApi
         /// <typeparam name="T">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST transaction request.</param>
         /// <returns>Response from ArangoDB after processing the request.</returns>
-        public async Task<PostTransactionResponse<T>> PostTransactionAsync<T>(PostTransactionBody body)
+        public virtual async Task<PostTransactionResponse<T>> PostTransactionAsync<T>(
+            PostTransactionBody body)
         {
             var content = GetContent(body, true, true);
             using (var response = await _client.PostAsync(_transactionApiPath, content))

--- a/arangodb-net-standard/UserApi/UserApiClient.cs
+++ b/arangodb-net-standard/UserApi/UserApiClient.cs
@@ -7,24 +7,52 @@ using ArangoDBNetStandard.UserApi.Models;
 
 namespace ArangoDBNetStandard.UserApi
 {
+    /// <summary>
+    /// A client for interacting with ArangoDB User Management endpoints,
+    /// implementing <see cref="IUserApiClient"/>.
+    /// </summary>
     public class UserApiClient : ApiClientBase, IUserApiClient
     {
-        private IApiClientTransport _client;
-        private readonly string _userApiPath = "_api/user";
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
+        protected IApiClientTransport _client;
 
+        /// <summary>
+        /// The root path of the API.
+        /// </summary>
+        protected readonly string _userApiPath = "_api/user";
+
+        /// <summary>
+        /// Creates an instance of <see cref="UserApiClient"/>
+        /// using the provided transport layer and the default JSON serialization.
+        /// </summary>
+        /// <param name="client"></param>
         public UserApiClient(IApiClientTransport client)
             : base(new JsonNetApiClientSerialization())
         {
             _client = client;
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="UserApiClient"/>
+        /// using the provided transport and serialization layers.
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="serializer"></param>
         public UserApiClient(IApiClientTransport client, IApiClientSerialization serializer)
             : base(serializer)
         {
             _client = client;
         }
 
-        public async Task<DeleteUserResponse> DeleteUserAsync(string username)
+        /// <summary>
+        /// Delete a user permanently.
+        /// You need Administrate for the server access level in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <returns></returns>
+        public virtual async Task<DeleteUserResponse> DeleteUserAsync(string username)
         {
             string uri = _userApiPath + "/" + WebUtility.HtmlEncode(username);
             using (var response = await _client.DeleteAsync(uri))


### PR DESCRIPTION
fix #206

Changes:
- Make public methods `virtual`
- Change private transport client and API path to protected

It would also be beneficial to allow extending the `HttpApiTransport` but I think that deserves its own issue/pull request.