### PR TITLE
Add _oldRev property in PatchDocumentsResponse.

### DIFF
--- a/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
+++ b/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
@@ -722,6 +722,7 @@ namespace ArangoDBNetStandardTest.DocumentApi
             Assert.NotEqual(postResponse[0]._rev, response[0]._rev);
             Assert.NotEqual(postResponse[0].New.Name, response[0].New.Name);
             Assert.Equal(postResponse[0].New.Name, response[0].Old.Name);
+            Assert.Equal(postResponse[0]._rev, response[0]._oldRev);
         }
 
         [Fact]

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -430,7 +430,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="patches"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public virtual async Task<IList<PatchDocumentsResponse<U>>> PatchDocumentsAsync<T, U>(
+        public virtual async Task<PatchDocumentsResponse<U>> PatchDocumentsAsync<T, U>(
             string collectionName,
             IList<T> patches,
             PatchDocumentsQuery query = null)
@@ -446,7 +446,7 @@ namespace ArangoDBNetStandard.DocumentApi
                 if (response.IsSuccessStatusCode)
                 {
                     var stream = await response.Content.ReadAsStreamAsync();
-                    return DeserializeJsonFromStream<IList<PatchDocumentsResponse<U>>>(stream);
+                    return DeserializeJsonFromStream<PatchDocumentsResponse<U>>(stream);
                 }
                 throw await GetApiErrorException(response);
             }

--- a/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/IDocumentApiClient.cs
@@ -224,7 +224,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// <param name="patches"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        Task<IList<PatchDocumentsResponse<U>>> PatchDocumentsAsync<T, U>(
+        Task<PatchDocumentsResponse<U>> PatchDocumentsAsync<T, U>(
           string collectionName,
           IList<T> patches,
           PatchDocumentsQuery query = null);

--- a/arangodb-net-standard/DocumentApi/Models/DeleteDocumentsResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/DeleteDocumentsResponse.cs
@@ -2,8 +2,15 @@
 
 namespace ArangoDBNetStandard.DocumentApi.Models
 {
+    /// <summary>
+    /// Represents the response for deleting multiple documents.
+    /// </summary>
+    /// <typeparam name="T">The type of the deserialized old document object when requested.</typeparam>
     public class DeleteDocumentsResponse<T> : List<DeleteDocumentsDocumentResponse<T>>
     {
+        /// <summary>
+        /// Creates an instance of <see cref="DeleteDocumentsResponse{T}"/>.
+        /// </summary>
         public DeleteDocumentsResponse()
         {
         }
@@ -13,6 +20,11 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         {
         }
 
+        /// <summary>
+        /// Creates an empty response.
+        /// This is used when <see cref="DeleteDocumentsQuery.Silent"/> is true.
+        /// </summary>
+        /// <returns></returns>
         public static DeleteDocumentsResponse<T> Empty()
         {
             return new DeleteDocumentsResponse<T>(0);

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentsDocumentResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentsDocumentResponse.cs
@@ -1,0 +1,24 @@
+﻿namespace ArangoDBNetStandard.DocumentApi.Models
+{
+    /// <summary>
+    /// Represents the response for one document when updating multiple document.
+    /// </summary>
+    /// <typeparam name="T">The type of the deserialized new/old document object when requested.</typeparam>
+    public class PatchDocumentsDocumentResponse<T> : PatchDocumentResponse<T>
+    {
+        /// <summary>
+        /// Indicates whether an error occurred.
+        /// </summary>
+        public bool Error { get; set; }
+
+        /// <summary>
+        /// Error message.
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// ArangoDB error number.
+        /// </summary>
+        public int ErrorNum { get; set; }
+    }
+}

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentsResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentsResponse.cs
@@ -1,14 +1,33 @@
-﻿namespace ArangoDBNetStandard.DocumentApi.Models
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.DocumentApi.Models
 {
-    public class PatchDocumentsResponse<T> : PatchDocumentResponse<T>
+    /// <summary>
+    /// Represents the response for updating multiple documents.
+    /// </summary>
+    /// <typeparam name="T">The type of the deserialized new/old document object when requested.</typeparam>
+    public class PatchDocumentsResponse<T> : List<PatchDocumentsDocumentResponse<T>>
     {
-        public bool Error { get; set; }
+        /// <summary>
+        /// Creates an instance of <see cref="PatchDocumentsResponse{T}"/>.
+        /// </summary>
+        public PatchDocumentsResponse()
+        {
+        }
+
+        private PatchDocumentsResponse(int capacity)
+            : base(capacity)
+        {
+        }
 
         /// <summary>
-        /// Error message.
+        /// Creates an empty response.
+        /// This is used when <see cref="PostDocumentsQuery.Silent"/> is true.
         /// </summary>
-        public string ErrorMessage { get; set; }
-
-        public int ErrorNum { get; set; }
+        /// <returns></returns>
+        public static PatchDocumentsResponse<T> Empty()
+        {
+            return new PatchDocumentsResponse<T>(0);
+        }
     }
 }

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentsResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentsResponse.cs
@@ -1,11 +1,7 @@
 ﻿namespace ArangoDBNetStandard.DocumentApi.Models
 {
-    public class PatchDocumentsResponse<U> : DocumentBase
+    public class PatchDocumentsResponse<T> : PatchDocumentResponse<T>
     {
-        public U New { get; set; }
-
-        public U Old { get; set; }
-
         public bool Error { get; set; }
 
         /// <summary>

--- a/arangodb-net-standard/DocumentApi/Models/PostDocumentsQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PostDocumentsQuery.cs
@@ -21,7 +21,9 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         public bool? ReturnOld { get; set; }
 
         /// <summary>
-        /// TODO
+        /// If set to true, an empty object will be returned as response.
+        /// No meta-data will be returned for the created document.
+        /// This option can be used to save some network traffic.
         /// </summary>
         public bool? Silent { get; set; }
 

--- a/arangodb-net-standard/DocumentApi/Models/PostDocumentsResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PostDocumentsResponse.cs
@@ -3,11 +3,14 @@
 namespace ArangoDBNetStandard.DocumentApi.Models
 {
     /// <summary>
-    /// Response after posting multiple documents
+    /// Represents the response for creating multiple documents.
     /// </summary>
-    /// <typeparam name="T"></typeparam>
+    /// <typeparam name="T">The type of the deserialized new/old document object when requested.</typeparam>
     public class PostDocumentsResponse<T> : List<PostDocumentsDocumentResponse<T>>
     {
+        /// <summary>
+        /// Creates an instance of <see cref="PostDocumentsResponse{T}"/>.
+        /// </summary>
         public PostDocumentsResponse()
         {
         }
@@ -17,6 +20,11 @@ namespace ArangoDBNetStandard.DocumentApi.Models
         {
         }
 
+        /// <summary>
+        /// Creates an empty response.
+        /// This is used when <see cref="PostDocumentsQuery.Silent"/> is true.
+        /// </summary>
+        /// <returns></returns>
         public static PostDocumentsResponse<T> Empty()
         {
             return new PostDocumentsResponse<T>(0);


### PR DESCRIPTION
fix #269

Quite close to #268 but that pull request was already up when I discovered that `_oldRev` was also missing.