### PR TITLE
Fix inconsistent usage of T and U types for body and response.

### DIFF
--- a/arangodb-net-standard.Test/GraphApi/GraphApiClientTest.cs
+++ b/arangodb-net-standard.Test/GraphApi/GraphApiClientTest.cs
@@ -1547,7 +1547,7 @@ namespace ArangoDBNetStandardTest.GraphApi
                     WaitForSync = true
                 });
 
-            var response = await _client.PatchEdgeAsync<PatchEdgeMockModel, object>(
+            var response = await _client.PatchEdgeAsync<object, PatchEdgeMockModel>(
                 graphName,
                 edgeClx,
                 createEdgeResponse.Edge._key,
@@ -1579,7 +1579,7 @@ namespace ArangoDBNetStandardTest.GraphApi
 
             var exception = await Assert.ThrowsAsync<ApiErrorException>(async () =>
             {
-                await _client.PatchEdgeAsync<PatchEdgeMockModel, object>(graphName, "edgeClx", "", new { });
+                await _client.PatchEdgeAsync<object, PatchEdgeMockModel>(graphName, "edgeClx", "", new { });
             });
 
             Assert.Equal(HttpStatusCode.NotFound, exception.ApiError.Code);

--- a/arangodb-net-standard/DocumentApi/Models/DeleteDocumentsDocumentResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/DeleteDocumentsDocumentResponse.cs
@@ -1,13 +1,24 @@
-﻿using System.Net;
-
-namespace ArangoDBNetStandard.DocumentApi.Models
+﻿namespace ArangoDBNetStandard.DocumentApi.Models
 {
-    public class DeleteDocumentsDocumentResponse<T>: DeleteDocumentResponse<T>
+    /// <summary>
+    /// Represents the response for one document when deleting multiple document.
+    /// </summary>
+    /// <typeparam name="T">The type of the deserialized old document object when requested.</typeparam>
+    public class DeleteDocumentsDocumentResponse<T> : DeleteDocumentResponse<T>
     {
+        /// <summary>
+        /// Indicates whether an error occurred.
+        /// </summary>
         public bool Error { get; set; }
 
+        /// <summary>
+        /// ArangoDB error message.
+        /// </summary>
         public string ErrorMessage { get; set; }
 
+        /// <summary>
+        /// ArangoDB error number.
+        /// </summary>
         public int ErrorNum { get; set; }
     }
 }

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentResponse.cs
@@ -3,20 +3,20 @@
     /// <summary>
     /// Represents a response returned when updating a single document.
     /// </summary>
-    /// <typeparam name="U">The type of the deserialized new/old document object when requested.</typeparam>
-    public class PatchDocumentResponse<U> : DocumentBase
+    /// <typeparam name="T">The type of the deserialized new/old document object when requested.</typeparam>
+    public class PatchDocumentResponse<T> : DocumentBase
     {
         /// <summary>
         /// Deserialized copy of the new document object. This will only be present if requested with the
         /// <see cref="PatchDocumentQuery.ReturnNew"/> option.
         /// </summary>
-        public U New { get; set; }
+        public T New { get; set; }
 
         /// <summary>
         /// Deserialized copy of the old document object. This will only be present if requested with the
         /// <see cref="PatchDocumentQuery.ReturnOld"/> option.
         /// </summary>
-        public U Old { get; set; }
+        public T Old { get; set; }
 
         /// <summary>
         /// Contains the revision of the old (now updated) document.

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentsDocumentResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentsDocumentResponse.cs
@@ -12,7 +12,7 @@
         public bool Error { get; set; }
 
         /// <summary>
-        /// Error message.
+        /// ArangoDB error message.
         /// </summary>
         public string ErrorMessage { get; set; }
 

--- a/arangodb-net-standard/DocumentApi/Models/PutDocumentsDocumentResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PutDocumentsDocumentResponse.cs
@@ -12,7 +12,7 @@
         public bool Error { get; set; }
 
         /// <summary>
-        /// Error message.
+        /// ArangoDB error message.
         /// </summary>
         public string ErrorMessage { get; set; }
 

--- a/arangodb-net-standard/GraphApi/GraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/GraphApiClient.cs
@@ -652,19 +652,20 @@ namespace ArangoDBNetStandard.GraphApi
         /// Updates the data of the specific edge in the collection.
         /// PATCH/_api/gharial/{graph}/edge/{collection}/{edge}
         /// </summary>
-        /// <typeparam name="T">Type of the returned edge document, when ReturnOld or ReturnNew query params are used.</typeparam>
-        /// <typeparam name="U">Type of the patch object used to perform a partial update of the edge document.</typeparam>
+        /// <typeparam name="T">Type of the patch object used to perform a partial update of the edge document.</typeparam>
+        /// <typeparam name="U">Type of the returned edge document,
+        /// when <see cref="PatchEdgeQuery.ReturnOld"/> or <see cref="PatchEdgeQuery.ReturnNew"/> query params are used.</typeparam>
         /// <param name="graphName"></param>
         /// <param name="collectionName"></param>
         /// <param name="edgeKey"></param>
         /// <param name="edge"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        public virtual async Task<PatchEdgeResponse<T>> PatchEdgeAsync<T, U>(
+        public virtual async Task<PatchEdgeResponse<U>> PatchEdgeAsync<T, U>(
             string graphName,
             string collectionName,
             string edgeKey,
-            U edge,
+            T edge,
             PatchEdgeQuery query = null)
         {
             var content = GetContent(edge, true, true);
@@ -682,7 +683,7 @@ namespace ArangoDBNetStandard.GraphApi
                 if (response.IsSuccessStatusCode)
                 {
                     var stream = await response.Content.ReadAsStreamAsync();
-                    return DeserializeJsonFromStream<PatchEdgeResponse<T>>(stream);
+                    return DeserializeJsonFromStream<PatchEdgeResponse<U>>(stream);
                 }
                 throw await GetApiErrorException(response);
             }

--- a/arangodb-net-standard/GraphApi/IGraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/IGraphApiClient.cs
@@ -297,19 +297,20 @@ namespace ArangoDBNetStandard.GraphApi
         /// Updates the data of the specific edge in the collection.
         /// PATCH/_api/gharial/{graph}/edge/{collection}/{edge}
         /// </summary>
-        /// <typeparam name="T">Type of the returned edge document, when ReturnOld or ReturnNew query params are used.</typeparam>
-        /// <typeparam name="U">Type of the patch object used to perform a partial update of the edge document.</typeparam>
+        /// <typeparam name="T">Type of the patch object used to perform a partial update of the edge document.</typeparam>
+        /// <typeparam name="U">Type of the returned edge document,
+        /// when <see cref="PatchEdgeQuery.ReturnOld"/> or <see cref="PatchEdgeQuery.ReturnNew"/> query params are used.</typeparam>
         /// <param name="graphName"></param>
         /// <param name="collectionName"></param>
         /// <param name="edgeKey"></param>
         /// <param name="edge"></param>
         /// <param name="query"></param>
         /// <returns></returns>
-        Task<PatchEdgeResponse<T>> PatchEdgeAsync<T, U>(
+        Task<PatchEdgeResponse<U>> PatchEdgeAsync<T, U>(
           string graphName,
           string collectionName,
           string edgeKey,
-          U edge,
+          T edge,
           PatchEdgeQuery query = null);
 
         /// <summary>


### PR DESCRIPTION
fix #266

I pulled a couple of changes from #270 and #268, please review/merge those first.

- Use `T` for body and `U` for response in `GraphApiClient.PatchEdgeAsync<T, U>` (that was the only one inconsistent)
- Use `T` instead of `U` for type name in response models
- Add comments on related response models