### PR TITLE
Implement remaining CRUD operation for user API.

### DIFF
--- a/arangodb-net-standard.Test/UserApi/UserApiClientTest.cs
+++ b/arangodb-net-standard.Test/UserApi/UserApiClientTest.cs
@@ -84,5 +84,113 @@ namespace ArangoDBNetStandardTest.UserApi
             Assert.NotNull(ex.ApiError.ErrorMessage);
             Assert.Equal(1702, ex.ApiError.ErrorNum); // ERROR_USER_DUPLICATE
         }
+
+        [Fact]
+        public async Task PutUserAsync_ShouldSucceed()
+        {
+            PutUserResponse response = await _userClient.PutUserAsync(
+                _fixture.UsernameExisting,
+                new PutUserBody()
+                {
+                    Extra = new Dictionary<string, object>()
+                    {
+                        ["somedata"] = nameof(PutUserAsync_ShouldSucceed)
+                    }
+                });
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.OK, response.Code);
+            Assert.Equal(_fixture.UsernameExisting, response.User);
+            Assert.True(response.Active);
+            Assert.True(response.Extra.ContainsKey("somedata"));
+            Assert.Equal(nameof(PutUserAsync_ShouldSucceed), response.Extra["somedata"].ToString());
+        }
+
+        [Fact]
+        public async Task PutUserAsync_ShouldThrow_WhenUserDoesNotExist()
+        {
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _userClient.PutUserAsync(
+                    nameof(PutUserAsync_ShouldThrow_WhenUserDoesNotExist),
+                    new PutUserBody()
+                    {
+                        Extra = new Dictionary<string, object>()
+                    });
+            });
+
+            Assert.True(ex.ApiError.Error);
+            Assert.Equal(HttpStatusCode.NotFound, ex.ApiError.Code);
+            Assert.NotNull(ex.ApiError.ErrorMessage);
+            Assert.Equal(1703, ex.ApiError.ErrorNum); // ERROR_USER_NOT_FOUND
+        }
+
+        [Fact]
+        public async Task PatchUserAsync_ShouldSucceed()
+        {
+            PatchUserResponse response = await _userClient.PatchUserAsync(
+                _fixture.UsernameExisting,
+                new PatchUserBody()
+                {
+                    Extra = new Dictionary<string, object>()
+                    {
+                        ["somedata"] = nameof(PatchUserAsync_ShouldSucceed)
+                    }
+                });
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.OK, response.Code);
+            Assert.Equal(_fixture.UsernameExisting, response.User);
+            Assert.True(response.Active);
+            Assert.True(response.Extra.ContainsKey("somedata"));
+            Assert.Equal(nameof(PatchUserAsync_ShouldSucceed), response.Extra["somedata"].ToString());
+        }
+
+        [Fact]
+        public async Task PatchUserAsync_ShouldThrow_WhenUserDoesNotExist()
+        {
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _userClient.PatchUserAsync(
+                    nameof(PatchUserAsync_ShouldThrow_WhenUserDoesNotExist),
+                    new PatchUserBody()
+                    {
+                        Extra = new Dictionary<string, object>()
+                    });
+            });
+
+            Assert.True(ex.ApiError.Error);
+            Assert.Equal(HttpStatusCode.NotFound, ex.ApiError.Code);
+            Assert.NotNull(ex.ApiError.ErrorMessage);
+            Assert.Equal(1703, ex.ApiError.ErrorNum); // ERROR_USER_NOT_FOUND
+        }
+
+        [Fact]
+        public async Task GetUserAsync_ShouldSucceed()
+        {
+            GetUserResponse response = await _userClient.GetUserAsync(
+                _fixture.UsernameExisting);
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.OK, response.Code);
+            Assert.Equal(_fixture.UsernameExisting, response.User);
+            Assert.True(response.Active);
+            Assert.NotNull(response.Extra);
+        }
+
+        [Fact]
+        public async Task GetUserAsync_ShouldThrow_WhenUserDoesNotExist()
+        {
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _userClient.GetUserAsync(
+                    nameof(GetUserAsync_ShouldThrow_WhenUserDoesNotExist));
+            });
+
+            Assert.True(ex.ApiError.Error);
+            Assert.Equal(HttpStatusCode.NotFound, ex.ApiError.Code);
+            Assert.NotNull(ex.ApiError.ErrorMessage);
+            Assert.Equal(1703, ex.ApiError.ErrorNum); // ERROR_USER_NOT_FOUND
+        }
     }
 }

--- a/arangodb-net-standard/UserApi/IUserApiClient.cs
+++ b/arangodb-net-standard/UserApi/IUserApiClient.cs
@@ -16,6 +16,41 @@ namespace ArangoDBNetStandard.UserApi
         /// <returns></returns>
         Task<PostUserResponse> PostUserAsync(PostUserBody body);
 
+        /// <summary>
+        /// Replace an existing user.
+        /// You need server access level Administrate in order to execute this REST call.
+        /// Additionally, a user can change his/her own data.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="body">The user information used for to replace operation.</param>
+        /// <returns></returns>
+        Task<PutUserResponse> PutUserAsync(string username, PutUserBody body);
+
+        /// <summary>
+        /// Partially update an existing user.
+        /// You need server access level Administrate in order to execute this REST call.
+        /// Additionally, a user can change his/her own data.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="body">The user information used for to replace operation.</param>
+        /// <returns></returns>
+        Task<PatchUserResponse> PatchUserAsync(string username, PatchUserBody body);
+
+        /// <summary>
+        /// Fetches data about the specified user.
+        /// You can fetch information about yourself or you need the Administrate
+        /// server access level in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <returns></returns>
+        Task<GetUserResponse> GetUserAsync(string username);
+
+        /// <summary>
+        /// Delete a user permanently.
+        /// You need Administrate for the server access level in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <returns></returns>
         Task<DeleteUserResponse> DeleteUserAsync(string username);
     }
 }

--- a/arangodb-net-standard/UserApi/Models/GetUserResponse.cs
+++ b/arangodb-net-standard/UserApi/Models/GetUserResponse.cs
@@ -1,0 +1,9 @@
+﻿namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a response returned after fetching a user.
+    /// </summary>
+    public class GetUserResponse : UserResponseBase
+    {
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/PatchUserBody.cs
+++ b/arangodb-net-standard/UserApi/Models/PatchUserBody.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a request body to update an existing user.
+    /// </summary>
+    public class PatchUserBody
+    {
+        /// <summary>
+        /// The user password. Specifying a password is mandatory,
+        /// but the empty string is allowed for passwords.
+        /// </summary>
+        public string Passwd { get; set; }
+
+        /// <summary>
+        /// An optional flag that specifies whether the user is active.
+        /// If not specified, this will default to true.
+        /// </summary>
+        public bool? Active { get; set; }
+
+        /// <summary>
+        /// Optional object with arbitrary extra data about the user.
+        /// </summary>
+        public Dictionary<string, object> Extra { get; set; }
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/PatchUserResponse.cs
+++ b/arangodb-net-standard/UserApi/Models/PatchUserResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Net;
+
+namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a response returned after updating an existing user.
+    /// </summary>
+    public class PatchUserResponse : UserResponseBase
+    {
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/PostUserResponse.cs
+++ b/arangodb-net-standard/UserApi/Models/PostUserResponse.cs
@@ -1,33 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Net;
-
-namespace ArangoDBNetStandard.UserApi.Models
+﻿namespace ArangoDBNetStandard.UserApi.Models
 {
-    public class PostUserResponse
+    /// <summary>
+    /// Represents a response returned after creating a user.
+    /// </summary>
+    public class PostUserResponse : UserResponseBase
     {
-        /// <summary>
-        /// The name of the user.
-        /// </summary>
-        public string User { get; set; }
-
-        /// <summary>
-        /// Whether the user is active.
-        /// </summary>
-        public bool Active { get; set; }
-
-        /// <summary>
-        /// Object with arbitrary extra data about the user.
-        /// </summary>
-        public Dictionary<string, object> Extra { get; set; }
-
-        /// <summary>
-        /// Indicates whether an error occurred (false in this case).
-        /// </summary>
-        public bool Error { get; set; }
-
-        /// <summary>
-        /// The HTTP status code.
-        /// </summary>
-        public HttpStatusCode Code { get; set; }
     }
 }

--- a/arangodb-net-standard/UserApi/Models/PutUserBody.cs
+++ b/arangodb-net-standard/UserApi/Models/PutUserBody.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a request body to replace an existing user.
+    /// </summary>
+    public class PutUserBody
+    {
+        /// <summary>
+        /// The user password. Specifying a password is mandatory,
+        /// but the empty string is allowed for passwords.
+        /// </summary>
+        public string Passwd { get; set; }
+
+        /// <summary>
+        /// An optional flag that specifies whether the user is active.
+        /// If not specified, this will default to true.
+        /// </summary>
+        public bool? Active { get; set; }
+
+        /// <summary>
+        /// Optional object with arbitrary extra data about the user.
+        /// </summary>
+        public Dictionary<string, object> Extra { get; set; }
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/PutUserResponse.cs
+++ b/arangodb-net-standard/UserApi/Models/PutUserResponse.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a response returned after replacing an existing user.
+    /// </summary>
+    public class PutUserResponse : UserResponseBase
+    {
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/UserResponseBase.cs
+++ b/arangodb-net-standard/UserApi/Models/UserResponseBase.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a common response class with user information
+    /// returned after performing an operation.
+    /// </summary>
+    public class UserResponseBase
+    {
+        /// <summary>
+        /// The name of the user.
+        /// </summary>
+        public string User { get; set; }
+
+        /// <summary>
+        /// Whether the user is active.
+        /// </summary>
+        public bool Active { get; set; }
+
+        /// <summary>
+        /// Object with arbitrary extra data about the user.
+        /// </summary>
+        public Dictionary<string, object> Extra { get; set; }
+
+        /// <summary>
+        /// Indicates whether an error occurred (false in this case).
+        /// </summary>
+        public bool Error { get; set; }
+
+        /// <summary>
+        /// The HTTP status code.
+        /// </summary>
+        public HttpStatusCode Code { get; set; }
+    }
+}

--- a/arangodb-net-standard/UserApi/UserApiClient.cs
+++ b/arangodb-net-standard/UserApi/UserApiClient.cs
@@ -53,7 +53,7 @@ namespace ArangoDBNetStandard.UserApi
         /// <exception cref="ApiErrorException">ArangoDB responded with an error.</exception>
         /// <param name="body">The request body containing the user information.</param>
         /// <returns></returns>
-        public async Task<PostUserResponse> PostUserAsync(PostUserBody body)
+        public virtual async Task<PostUserResponse> PostUserAsync(PostUserBody body)
         {
             var content = GetContent(body, true, true);
             using (var response = await _client.PostAsync(_userApiPath, content))
@@ -62,6 +62,73 @@ namespace ArangoDBNetStandard.UserApi
                 {
                     var stream = await response.Content.ReadAsStreamAsync();
                     return DeserializeJsonFromStream<PostUserResponse>(stream);
+                }
+                throw await GetApiErrorException(response);
+            }
+        }
+
+        /// <summary>
+        /// Replace an existing user.
+        /// You need server access level Administrate in order to execute this REST call.
+        /// Additionally, a user can change his/her own data.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="body">The user information used for to replace operation.</param>
+        /// <returns></returns>
+        public virtual async Task<PutUserResponse> PutUserAsync(string username, PutUserBody body)
+        {
+            string uri = _userApiPath + '/' + username;
+            var content = GetContent(body, true, true);
+            using (var response = await _client.PutAsync(uri, content))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<PutUserResponse>(stream);
+                }
+                throw await GetApiErrorException(response);
+            }
+        }
+
+        /// <summary>
+        /// Partially update an existing user.
+        /// You need server access level Administrate in order to execute this REST call.
+        /// Additionally, a user can change his/her own data.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="body">The user information used for to replace operation.</param>
+        /// <returns></returns>
+        public virtual async Task<PatchUserResponse> PatchUserAsync(string username, PatchUserBody body)
+        {
+            string uri = _userApiPath + '/' + username;
+            var content = GetContent(body, true, true);
+            using (var response = await _client.PatchAsync(uri, content))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<PatchUserResponse>(stream);
+                }
+                throw await GetApiErrorException(response);
+            }
+        }
+
+        /// <summary>
+        /// Fetches data about the specified user.
+        /// You can fetch information about yourself or you need the Administrate
+        /// server access level in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <returns></returns>
+        public virtual async Task<GetUserResponse> GetUserAsync(string username)
+        {
+            string uri = _userApiPath + '/' + username;
+            using (var response = await _client.GetAsync(uri))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<GetUserResponse>(stream);
                 }
                 throw await GetApiErrorException(response);
             }


### PR DESCRIPTION
fix #277

- Added the following methods in `UserApiClient`: `PutUserAsync`, `PatchUserAsync` and `GetUserAsync`.
- Added related data models for body and response + `UserResponseBase` which contains the base properties common to GET, POST, PUT, PATCH responses.
- Also added related unit tests.