### PR TITLE
Add missing silent parameter in query models for multiple documents

### DIFF
--- a/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
+++ b/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
@@ -674,6 +674,81 @@ namespace ArangoDBNetStandardTest.DocumentApi
         }
 
         [Fact]
+        public async Task PutDocumentsAsync_ShouldUseQueryParameters_WhenProvided()
+        {
+            var mockTransport = new Mock<IApiClientTransport>();
+
+            var mockResponse = new Mock<IApiClientResponse>();
+
+            var mockResponseContent = new Mock<IApiClientResponseContent>();
+
+            mockResponse.Setup(x => x.Content)
+                .Returns(mockResponseContent.Object);
+
+            mockResponse.Setup(x => x.IsSuccessStatusCode)
+                .Returns(true);
+
+            string requestUri = null;
+
+            mockTransport.Setup(x => x.PutAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Returns((string uri, byte[] content) =>
+                {
+                    requestUri = uri;
+                    return Task.FromResult(mockResponse.Object);
+                });
+
+            var client = new DocumentApiClient(mockTransport.Object);
+
+            await client.PutDocumentsAsync<object>(
+                "mycollection",
+                new[]
+                {
+                    new { Value = 1, Name = "test1" }
+                },
+                new PutDocumentsQuery
+                {
+                    IgnoreRevs = true,
+                    ReturnOld = true,
+                    Silent = true,
+                    WaitForSync = true,
+                    ReturnNew = true
+                });
+
+            Assert.NotNull(requestUri);
+            Assert.Contains("ignoreRevs=true", requestUri);
+            Assert.Contains("returnOld=true", requestUri);
+            Assert.Contains("silent=true", requestUri);
+            Assert.Contains("waitForSync=true", requestUri);
+            Assert.Contains("returnNew=true", requestUri);
+        }
+
+        [Fact]
+        public async Task PutDocumentsAsync_ShouldSucceed_WhenSilent()
+        {
+            var postResponse = await _docClient.PostDocumentsAsync(
+                _testCollection,
+                new[]
+                {
+                    new { value = 1 },
+                    new { value = 2 }
+                });
+
+            var putResponse = await _docClient.PutDocumentsAsync(
+                _testCollection,
+                new[]
+                {
+                    new { postResponse[0]._key, value = 3 },
+                    new { postResponse[1]._key, value = 4 }
+                },
+                new PutDocumentsQuery()
+                {
+                    Silent = true
+                });
+
+            Assert.Empty(putResponse);
+        }
+
+        [Fact]
         public async Task PutDocuments_ShouldNotThrowButReturnError_WhenDocumentIsNotFound()
         {
             var response = await _docClient.PostDocumentsAsync(_testCollection,
@@ -753,7 +828,8 @@ namespace ArangoDBNetStandardTest.DocumentApi
 
             await client.PatchDocumentsAsync<object, object>(
                 "mycollection",
-                new[] {
+                new[]
+                {
                     new { Value = 1, Name = "test1" },
                     new { Value = 2, Name = "test2" },
                     new { Value = 3, Name = "test3" }
@@ -784,7 +860,8 @@ namespace ArangoDBNetStandardTest.DocumentApi
         {
             var postResponse = await _docClient.PostDocumentsAsync(
                 _testCollection,
-                new[] {
+                new[]
+                {
                     new { Value = 1, Name = "test1" },
                     new { Value = 2, Name = "test2" },
                     new { Value = 3, Name = "test3" }
@@ -797,7 +874,8 @@ namespace ArangoDBNetStandardTest.DocumentApi
 
             var response = await _docClient.PatchDocumentsAsync<object, PatchDocumentsMockModel>(
                 _testCollection,
-                new[] {
+                new[]
+                {
                     new { postResponse[0]._key, Name = "test5" },
                     new { postResponse[1]._key, Name = "test4" }
                 },

--- a/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
+++ b/arangodb-net-standard.Test/DocumentApi/DocumentApiClientTest.cs
@@ -726,6 +726,90 @@ namespace ArangoDBNetStandardTest.DocumentApi
         }
 
         [Fact]
+        public async Task PatchDocumentsAsync_ShouldUseQueryParameters_WhenProvided()
+        {
+            var mockTransport = new Mock<IApiClientTransport>();
+
+            var mockResponse = new Mock<IApiClientResponse>();
+
+            var mockResponseContent = new Mock<IApiClientResponseContent>();
+
+            mockResponse.Setup(x => x.Content)
+                .Returns(mockResponseContent.Object);
+
+            mockResponse.Setup(x => x.IsSuccessStatusCode)
+                .Returns(true);
+
+            string requestUri = null;
+
+            mockTransport.Setup(x => x.PatchAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Returns((string uri, byte[] content) =>
+                {
+                    requestUri = uri;
+                    return Task.FromResult(mockResponse.Object);
+                });
+
+            var client = new DocumentApiClient(mockTransport.Object);
+
+            await client.PatchDocumentsAsync<object, object>(
+                "mycollection",
+                new[] {
+                    new { Value = 1, Name = "test1" },
+                    new { Value = 2, Name = "test2" },
+                    new { Value = 3, Name = "test3" }
+                },
+                new PatchDocumentsQuery
+                {
+                    IgnoreRevs = true,
+                    ReturnOld = true,
+                    Silent = true,
+                    WaitForSync = true,
+                    KeepNull = true,
+                    MergeObjects = true,
+                    ReturnNew = true
+                });
+
+            Assert.NotNull(requestUri);
+            Assert.Contains("ignoreRevs=true", requestUri);
+            Assert.Contains("returnOld=true", requestUri);
+            Assert.Contains("silent=true", requestUri);
+            Assert.Contains("waitForSync=true", requestUri);
+            Assert.Contains("keepNull=true", requestUri);
+            Assert.Contains("mergeObjects=true", requestUri);
+            Assert.Contains("returnNew=true", requestUri);
+        }
+
+        [Fact]
+        public async Task PatchDocumentsAsync_ShouldSucceed_WhenSilent()
+        {
+            var postResponse = await _docClient.PostDocumentsAsync(
+                _testCollection,
+                new[] {
+                    new { Value = 1, Name = "test1" },
+                    new { Value = 2, Name = "test2" },
+                    new { Value = 3, Name = "test3" }
+                },
+                new PostDocumentsQuery
+                {
+                    ReturnNew = true,
+                    WaitForSync = true
+                });
+
+            var response = await _docClient.PatchDocumentsAsync<object, PatchDocumentsMockModel>(
+                _testCollection,
+                new[] {
+                    new { postResponse[0]._key, Name = "test5" },
+                    new { postResponse[1]._key, Name = "test4" }
+                },
+                new PatchDocumentsQuery
+                {
+                    Silent = true
+                });
+
+            Assert.Empty(response);
+        }
+
+        [Fact]
         public async Task PatchDocumentsAsync_ShouldReturnError_WhenDocumentDoesNotExist()
         {
             var response = await _docClient.PatchDocumentsAsync<object, PatchDocumentsMockModel>(

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -408,9 +408,7 @@ namespace ArangoDBNetStandard.DocumentApi
 
         /// <summary>
         /// Partially updates documents, the documents to update are specified
-        /// by the _key attributes in the body objects.The body of the
-        /// request must contain a JSON array of document updates with the
-        /// attributes to patch(the patch documents). All attributes from the
+        /// by the _key attributes in the body objects. All attributes from the
         /// patch documents will be added to the existing documents if they do
         /// not yet exist, and overwritten in the existing documents if they do
         /// exist there.
@@ -420,7 +418,7 @@ namespace ArangoDBNetStandard.DocumentApi
         /// document in the body and its value does not match the revision of
         /// the corresponding document in the database, the precondition is
         /// violated.
-        /// PATCH/_api/document/{collection}
+        /// PATCH /_api/document/{collection}
         /// </summary>
         /// <typeparam name="T">Type of the patch object used to partially update documents.</typeparam>
         /// <typeparam name="U">Type of the returned documents, only applies when
@@ -445,8 +443,15 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 if (response.IsSuccessStatusCode)
                 {
-                    var stream = await response.Content.ReadAsStreamAsync();
-                    return DeserializeJsonFromStream<PatchDocumentsResponse<U>>(stream);
+                    if (query != null && query.Silent.HasValue && query.Silent.Value)
+                    {
+                        return PatchDocumentsResponse<U>.Empty();
+                    }
+                    else
+                    {
+                        var stream = await response.Content.ReadAsStreamAsync();
+                        return DeserializeJsonFromStream<PatchDocumentsResponse<U>>(stream);
+                    }
                 }
                 throw await GetApiErrorException(response);
             }

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -135,8 +135,15 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 if (response.IsSuccessStatusCode)
                 {
-                    var stream = await response.Content.ReadAsStreamAsync();
-                    return DeserializeJsonFromStream<PutDocumentsResponse<T>>(stream);
+                    if (query != null && query.Silent.HasValue && query.Silent.Value)
+                    {
+                        return PutDocumentsResponse<T>.Empty();
+                    }
+                    else
+                    {
+                        var stream = await response.Content.ReadAsStreamAsync();
+                        return DeserializeJsonFromStream<PutDocumentsResponse<T>>(stream);
+                    }
                 }
                 throw await GetApiErrorException(response);
             }

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentsQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentsQuery.cs
@@ -2,19 +2,60 @@
 
 namespace ArangoDBNetStandard.DocumentApi.Models
 {
+    /// <summary>
+    /// Represents query parameters used when updating multiple documents.
+    /// </summary>
     public class PatchDocumentsQuery
     {
+        /// <summary>
+        /// If the intention is to delete existing attributes with the patch command,
+        /// this query parameter can be used with a value of false.
+        /// This will modify the behavior of the patch command to remove any attributes
+        /// from the existing document that are contained in the patch document with an attribute value of null.
+        /// </summary>
         public bool? KeepNull { get; set; }
 
+        /// <summary>
+        /// Controls whether objects (not arrays) will be merged
+        /// if present in both the existing and the patch document.
+        /// If set to false, the value in the patch document will
+        /// overwrite the existing document’s value.
+        /// If set to true, objects will be merged.
+        /// The default is true.
+        /// </summary>
         public bool? MergeObjects { get; set; }
 
+        /// <summary>
+        /// Wait until the new documents have been synced to disk.
+        /// </summary>
         public bool? WaitForSync { get; set; }
 
+        /// <summary>
+        /// By default, or if this is set to true, the _rev attributes
+        /// in the given documents are ignored.
+        /// If this is set to false, then any _rev attribute given
+        /// in a body document is taken as a precondition.
+        /// The document is only updated if the current revision is the one specified.
+        /// </summary>
         public bool? IgnoreRevs { get; set; }
 
+        /// <summary>
+        /// Return additionally the complete previous revision
+        /// of the changed documents in the result.
+        /// </summary>
         public bool? ReturnOld { get; set; }
 
+        /// <summary>
+        /// Return additionally the complete new documents in the result.
+        /// </summary>
         public bool? ReturnNew { get; set; }
+
+        /// <summary>
+        /// If set to true, an empty object will be returned as response.
+        /// No meta-data will be returned for the created document.
+        /// This option can be used to save some network traffic.
+        /// </summary>
+        public bool? Silent { get; set; }
 
         internal string ToQueryString()
         {
@@ -42,6 +83,10 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (ReturnNew != null)
             {
                 queryParams.Add("returnNew=" + ReturnNew.ToString().ToLower());
+            }
+            if (Silent != null)
+            {
+                queryParams.Add("silent=" + Silent.ToString().ToLower());
             }
             return string.Join("&", queryParams);
         }

--- a/arangodb-net-standard/DocumentApi/Models/PatchDocumentsResponse.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PatchDocumentsResponse.cs
@@ -22,7 +22,7 @@ namespace ArangoDBNetStandard.DocumentApi.Models
 
         /// <summary>
         /// Creates an empty response.
-        /// This is used when <see cref="PostDocumentsQuery.Silent"/> is true.
+        /// This is used when <see cref="PatchDocumentsQuery.Silent"/> is true.
         /// </summary>
         /// <returns></returns>
         public static PatchDocumentsResponse<T> Empty()

--- a/arangodb-net-standard/DocumentApi/Models/PutDocumentsQuery.cs
+++ b/arangodb-net-standard/DocumentApi/Models/PutDocumentsQuery.cs
@@ -26,15 +26,22 @@ namespace ArangoDBNetStandard.DocumentApi.Models
 
         /// <summary>
         /// Whether to return the complete previous revision of the changed
-        /// documents under <see cref="PostDocumentResponse{T}.Old"/>.
+        /// documents in the result.
         /// </summary>
         public bool? ReturnOld { get; set; }
 
         /// <summary>
         /// Whether to return the complete new revision of the changed
-        /// documents under <see cref="PostDocumentResponse{T}.New"/>.
+        /// documents in the result.
         /// </summary>
         public bool? ReturnNew { get; set; }
+
+        /// <summary>
+        /// If set to true, an empty object will be returned as response.
+        /// No meta-data will be returned for the created document.
+        /// This option can be used to save some network traffic.
+        /// </summary>
+        public bool? Silent { get; set; }
 
         /// <summary>
         /// Get the set of options in a format suited to a URL query string.
@@ -58,6 +65,10 @@ namespace ArangoDBNetStandard.DocumentApi.Models
             if (IgnoreRevs != null)
             {
                 query.Add("ignoreRevs=" + IgnoreRevs.ToString().ToLower());
+            }
+            if (Silent != null)
+            {
+                query.Add("silent=" + Silent.ToString().ToLower());
             }
             return string.Join("&", query);
         }


### PR DESCRIPTION
fix #273 

Updated `PatchDocumentsQuery` and `PutDocumentsQuery` to include a `Silent` parameter. Updated endpoint methods accordingly + related unit tests.