### PR TITLE
Implement access level methods in UserApiClient.

### DIFF
--- a/arangodb-net-standard.Test/UserApi/UserApiClientTest.cs
+++ b/arangodb-net-standard.Test/UserApi/UserApiClientTest.cs
@@ -1,8 +1,13 @@
 ﻿using ArangoDBNetStandard;
+using ArangoDBNetStandard.Transport;
 using ArangoDBNetStandard.UserApi;
 using ArangoDBNetStandard.UserApi.Models;
+using Moq;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -185,6 +190,359 @@ namespace ArangoDBNetStandardTest.UserApi
             {
                 await _userClient.GetUserAsync(
                     nameof(GetUserAsync_ShouldThrow_WhenUserDoesNotExist));
+            });
+
+            Assert.True(ex.ApiError.Error);
+            Assert.Equal(HttpStatusCode.NotFound, ex.ApiError.Code);
+            Assert.NotNull(ex.ApiError.ErrorMessage);
+            Assert.Equal(1703, ex.ApiError.ErrorNum); // ERROR_USER_NOT_FOUND
+        }
+
+        [Fact]
+        public async Task PutDatabaseAccessLevelAsync_ShouldSucceed()
+        {
+            PutAccessLevelResponse response =
+                await _userClient.PutDatabaseAccessLevelAsync(
+                    _fixture.UsernameExisting,
+                    "_system",
+                    new PutAccessLevelBody()
+                    {
+                        Grant = "rw"
+                    });
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.OK, response.Code);
+        }
+
+        [Fact]
+        public async Task PutDatabaseAccessLevelAsync_ShouldThrow_WhenUserDoesNotExist()
+        {
+            string username = nameof(PutDatabaseAccessLevelAsync_ShouldThrow_WhenUserDoesNotExist);
+
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _userClient.PutDatabaseAccessLevelAsync(
+                    username,
+                    "_system",
+                    new PutAccessLevelBody()
+                    {
+                        Grant = "rw"
+                    });
+            });
+
+            Assert.True(ex.ApiError.Error);
+            Assert.Equal(HttpStatusCode.NotFound, ex.ApiError.Code);
+            Assert.NotNull(ex.ApiError.ErrorMessage);
+            Assert.Equal(1703, ex.ApiError.ErrorNum); // ERROR_USER_NOT_FOUND
+        }
+
+        [Fact]
+        public async Task GetDatabaseAccessLevelAsync_ShouldSucceed()
+        {
+            GetAccessLevelResponse response =
+                await _userClient.GetDatabaseAccessLevelAsync(
+                    _fixture.UsernameExisting,
+                    _fixture.TestDbName);
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.OK, response.Code);
+            Assert.False(string.IsNullOrEmpty(response.Result));
+        }
+
+        [Fact]
+        public async Task GetDatabaseAccessLevelAsync_ShouldThrow_WhenErrorResponseReturned()
+        {
+            // Arrange
+
+            var mockTransport = new Mock<IApiClientTransport>();
+
+            var mockResponse = new Mock<IApiClientResponse>();
+
+            var mockResponseContent = new Mock<IApiClientResponseContent>();
+
+            string mockJsonResponse = "{\"error\":true,\"errorMessage\":\"user not found\",\"errorNum\":1703,\"code\":404}";
+
+            mockResponseContent.Setup(x => x.ReadAsStreamAsync())
+                .Returns(Task.FromResult<Stream>(
+                    new MemoryStream(Encoding.UTF8.GetBytes(mockJsonResponse))));
+
+            mockResponse.Setup(x => x.Content)
+                .Returns(mockResponseContent.Object);
+
+            mockResponse.Setup(x => x.IsSuccessStatusCode)
+                .Returns(false);
+
+            string requestUri = null;
+
+            mockTransport.Setup(x => x.GetAsync(It.IsAny<string>()))
+                .Returns((string uri) =>
+                {
+                    requestUri = uri;
+                    return Task.FromResult(mockResponse.Object);
+                });
+
+            var client = new UserApiClient(mockTransport.Object);
+
+            // Act
+
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await client.GetDatabaseAccessLevelAsync("", "");
+            });
+
+            // Assert
+
+            Assert.True(ex.ApiError.Error);
+            Assert.Equal(HttpStatusCode.NotFound, ex.ApiError.Code);
+            Assert.NotNull(ex.ApiError.ErrorMessage);
+            Assert.Equal(1703, ex.ApiError.ErrorNum); // ERROR_USER_NOT_FOUND
+        }
+
+        [Fact]
+        public async Task DeleteDatabaseAccessLevelAsync_ShouldSucceed()
+        {
+            DeleteAccessLevelResponse response =
+                await _userClient.DeleteDatabaseAccessLevelAsync(
+                    _fixture.UsernameToRemoveAccess,
+                    _fixture.TestDbName);
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.Accepted, response.Code);
+        }
+
+        [Fact]
+        public async Task DeleteDatabaseAccessLevelAsync_ShouldThrow_WhenUserDoesNotExist()
+        {
+            string username = nameof(DeleteDatabaseAccessLevelAsync_ShouldThrow_WhenUserDoesNotExist);
+
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _userClient.DeleteDatabaseAccessLevelAsync(username, "_system");
+            });
+
+            Assert.True(ex.ApiError.Error);
+            Assert.Equal(HttpStatusCode.NotFound, ex.ApiError.Code);
+            Assert.NotNull(ex.ApiError.ErrorMessage);
+            Assert.Equal(1703, ex.ApiError.ErrorNum); // ERROR_USER_NOT_FOUND
+        }
+
+        [Fact]
+        public async Task GetAccessibleDatabasesAsync_ShouldSucceed()
+        {
+            GetAccessibleDatabasesResponse response =
+                await _userClient.GetAccessibleDatabasesAsync(_fixture.UsernameExisting);
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.OK, response.Code);
+            Assert.NotNull(response.Result);
+            Assert.True(response.Result.Keys.Count > 0);
+
+            string accessLevel = response.Result[response.Result.Keys.First()].ToString();
+            Assert.False(string.IsNullOrEmpty(accessLevel));
+        }
+
+        [Fact]
+        public async Task GetAccessibleDatabasesAsync_ShouldUseQueryParameters_WhenProvided()
+        {
+            var mockTransport = new Mock<IApiClientTransport>();
+
+            var mockResponse = new Mock<IApiClientResponse>();
+
+            var mockResponseContent = new Mock<IApiClientResponseContent>();
+
+            mockResponse.Setup(x => x.Content)
+                .Returns(mockResponseContent.Object);
+
+            mockResponse.Setup(x => x.IsSuccessStatusCode)
+                .Returns(true);
+
+            string requestUri = null;
+
+            mockTransport.Setup(x => x.GetAsync(It.IsAny<string>()))
+                .Returns((string uri) =>
+                {
+                    requestUri = uri;
+                    return Task.FromResult(mockResponse.Object);
+                });
+
+            var client = new UserApiClient(mockTransport.Object);
+
+            await client.GetAccessibleDatabasesAsync("", new GetAccessibleDatabasesQuery()
+            {
+                Full = true
+            });
+
+            Assert.NotNull(requestUri);
+            Assert.Contains("full=true", requestUri);
+        }
+
+        [Fact]
+        public async Task GetAccessibleDatabasesAsync_ShouldSucceed_WhenFullIsProvided()
+        {
+            GetAccessibleDatabasesResponse response =
+                await _userClient.GetAccessibleDatabasesAsync(
+                    _fixture.UsernameExisting,
+                    new GetAccessibleDatabasesQuery()
+                    {
+                        Full = true
+                    });
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.OK, response.Code);
+            Assert.NotNull(response.Result);
+            Assert.True(response.Result.Keys.Count > 0);
+
+            object accessLevel = response.Result[response.Result.Keys.First()];
+            var jObject = accessLevel as Newtonsoft.Json.Linq.JObject;
+
+            Assert.NotNull(jObject);
+            Assert.True(jObject.ContainsKey("permission"));
+            Assert.True(jObject.ContainsKey("collections"));
+        }
+
+        [Fact]
+        public async Task GetAccessibleDatabasesAsync_ShouldThrow_WhenUserDoesNotExist()
+        {
+            string username = nameof(GetAccessibleDatabasesAsync_ShouldThrow_WhenUserDoesNotExist);
+
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _userClient.GetAccessibleDatabasesAsync(username);
+            });
+
+            Assert.True(ex.ApiError.Error);
+            Assert.Equal(HttpStatusCode.NotFound, ex.ApiError.Code);
+            Assert.NotNull(ex.ApiError.ErrorMessage);
+            Assert.Equal(1703, ex.ApiError.ErrorNum); // ERROR_USER_NOT_FOUND
+        }
+
+        [Fact]
+        public async Task PutCollectionAccessLevelAsync_ShouldSucceed()
+        {
+            PutAccessLevelResponse response =
+                await _userClient.PutCollectionAccessLevelAsync(
+                    _fixture.UsernameExisting,
+                    _fixture.TestDbName,
+                    _fixture.CollectionNameToSetAccess,
+                    new PutAccessLevelBody()
+                    {
+                        Grant = "rw"
+                    });
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.OK, response.Code);
+        }
+
+        [Fact]
+        public async Task PutCollectionAccessLevelAsync_ShouldThrow_WhenUserDoesNotExist()
+        {
+            string username = nameof(PutCollectionAccessLevelAsync_ShouldThrow_WhenUserDoesNotExist);
+
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _userClient.PutCollectionAccessLevelAsync(
+                    username,
+                    _fixture.TestDbName,
+                    _fixture.CollectionNameToSetAccess,
+                    new PutAccessLevelBody()
+                    {
+                        Grant = "rw"
+                    });
+            });
+
+            Assert.True(ex.ApiError.Error);
+            Assert.Equal(HttpStatusCode.NotFound, ex.ApiError.Code);
+            Assert.NotNull(ex.ApiError.ErrorMessage);
+            Assert.Equal(1703, ex.ApiError.ErrorNum); // ERROR_USER_NOT_FOUND
+        }
+
+        [Fact]
+        public async Task GetCollectionAccessLevelAsync_ShouldSucceed()
+        {
+            GetAccessLevelResponse response =
+                await _userClient.GetCollectionAccessLevelAsync(
+                    _fixture.UsernameExisting,
+                    _fixture.TestDbName,
+                    _fixture.CollectionNameToSetAccess);
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.OK, response.Code);
+            Assert.False(string.IsNullOrEmpty(response.Result));
+        }
+
+        [Fact]
+        public async Task GetCollectionAccessLevelAsync_ShouldThrow_WhenErrorResponseReturned()
+        {
+            // Arrange
+
+            var mockTransport = new Mock<IApiClientTransport>();
+
+            var mockResponse = new Mock<IApiClientResponse>();
+
+            var mockResponseContent = new Mock<IApiClientResponseContent>();
+
+            string mockJsonResponse = "{\"error\":true,\"errorMessage\":\"user not found\",\"errorNum\":1703,\"code\":404}";
+
+            mockResponseContent.Setup(x => x.ReadAsStreamAsync())
+                .Returns(Task.FromResult<Stream>(
+                    new MemoryStream(Encoding.UTF8.GetBytes(mockJsonResponse))));
+
+            mockResponse.Setup(x => x.Content)
+                .Returns(mockResponseContent.Object);
+
+            mockResponse.Setup(x => x.IsSuccessStatusCode)
+                .Returns(false);
+
+            string requestUri = null;
+
+            mockTransport.Setup(x => x.GetAsync(It.IsAny<string>()))
+                .Returns((string uri) =>
+                {
+                    requestUri = uri;
+                    return Task.FromResult(mockResponse.Object);
+                });
+
+            var client = new UserApiClient(mockTransport.Object);
+
+            // Act
+
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await client.GetCollectionAccessLevelAsync("", "", "");
+            });
+
+            // Assert
+
+            Assert.True(ex.ApiError.Error);
+            Assert.Equal(HttpStatusCode.NotFound, ex.ApiError.Code);
+            Assert.NotNull(ex.ApiError.ErrorMessage);
+            Assert.Equal(1703, ex.ApiError.ErrorNum); // ERROR_USER_NOT_FOUND
+        }
+
+        [Fact]
+        public async Task DeleteCollectionAccessLevelAsync_ShouldSucceed()
+        {
+            DeleteAccessLevelResponse response =
+                await _userClient.DeleteCollectionAccessLevelAsync(
+                    _fixture.UsernameToRemoveAccess,
+                    _fixture.TestDbName,
+                    _fixture.CollectionNameToRemoveAccess);
+
+            Assert.False(response.Error);
+            Assert.Equal(HttpStatusCode.Accepted, response.Code);
+        }
+
+        [Fact]
+        public async Task DeleteCollectionAccessLevelAsync_ShouldThrow_WhenUserDoesNotExist()
+        {
+            string username = nameof(DeleteCollectionAccessLevelAsync_ShouldThrow_WhenUserDoesNotExist);
+
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _userClient.DeleteCollectionAccessLevelAsync(
+                    username,
+                    _fixture.TestDbName,
+                    _fixture.CollectionNameToRemoveAccess);
             });
 
             Assert.True(ex.ApiError.Error);

--- a/arangodb-net-standard.Test/UserApi/UserApiClientTestFixture.cs
+++ b/arangodb-net-standard.Test/UserApi/UserApiClientTestFixture.cs
@@ -1,4 +1,5 @@
 ﻿using ArangoDBNetStandard;
+using ArangoDBNetStandard.CollectionApi.Models;
 using ArangoDBNetStandard.DatabaseApi.Models;
 using System;
 using System.Threading.Tasks;
@@ -12,27 +13,37 @@ namespace ArangoDBNetStandardTest.UserApi
     {
         public ArangoDBClient ArangoClient { get; private set; }
 
+        public string TestDbName { get; private set; }
+
         public string UsernameToDelete { get; private set; }
 
         public string UsernameToCreate { get; private set; }
 
         public string UsernameExisting { get; private set; }
 
+        public string UsernameToRemoveAccess { get; private set; }
+
+        public string CollectionNameToSetAccess { get; private set; }
+
+        public string CollectionNameToRemoveAccess { get; private set; }
+
         public UserApiClientTestFixture()
         {
             ArangoClient = GetArangoDBClient("_system");
+            TestDbName = nameof(UserApiClientTestFixture);
             UsernameToDelete = nameof(UserApiClientTestFixture) + "Delete";
             UsernameToCreate = nameof(UserApiClientTestFixture) + "Post";
             UsernameExisting = nameof(UserApiClientTestFixture) + "Existing";
+            UsernameToRemoveAccess = nameof(UserApiClientTestFixture) + "DeleteAccess";
+            CollectionNameToSetAccess = "CollectionToSetAccess";
+            CollectionNameToRemoveAccess = "CollectionToRemoveAccess";
         }
 
         public override async Task InitializeAsync()
         {
             await base.InitializeAsync();
 
-            string dbName = nameof(UserApiClientTestFixture);
-
-            await CreateDatabase(dbName, new DatabaseUser[]
+            await CreateDatabase(TestDbName, new DatabaseUser[]
             {
                 new DatabaseUser()
                 {
@@ -41,7 +52,23 @@ namespace ArangoDBNetStandardTest.UserApi
                 new DatabaseUser()
                 {
                     Username = UsernameExisting
+                },
+                new DatabaseUser()
+                {
+                    Username = UsernameToRemoveAccess
                 }
+            });
+
+            var dbClient = GetArangoDBClient(TestDbName);
+
+            await dbClient.Collection.PostCollectionAsync(new PostCollectionBody()
+            {
+                Name = CollectionNameToSetAccess
+            });
+
+            await dbClient.Collection.PostCollectionAsync(new PostCollectionBody()
+            {
+                Name = CollectionNameToRemoveAccess
             });
 
             _users.Add(UsernameToCreate);

--- a/arangodb-net-standard/UserApi/IUserApiClient.cs
+++ b/arangodb-net-standard/UserApi/IUserApiClient.cs
@@ -52,5 +52,95 @@ namespace ArangoDBNetStandard.UserApi
         /// <param name="username">The name of the user.</param>
         /// <returns></returns>
         Task<DeleteUserResponse> DeleteUserAsync(string username);
+
+        /// <summary>
+        /// Sets the database access levels of a user for a given database.
+        /// You need the Administrate server access level in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database.</param>
+        /// <param name="body">The body of the request containing the access level.</param>
+        /// <returns></returns>
+        Task<PutAccessLevelResponse> PutDatabaseAccessLevelAsync(
+            string username,
+            string dbName,
+            PutAccessLevelBody body);
+
+        /// <summary>
+        /// Gets specific database access level for a user.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database to query.</param>
+        /// <param name="body">The body of the request containing the access level.</param>
+        /// <returns></returns>
+        Task<GetAccessLevelResponse> GetDatabaseAccessLevelAsync(
+            string username,
+            string dbName);
+
+        /// <summary>
+        /// Clears the database access levels of a user for a given database.
+        /// As consequence the default database access level is used.
+        /// If there is no defined default database access level, it defaults to 'No access'.
+        /// You need permission to the '_system' database in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database.</param>
+        /// <returns></returns>
+        Task<DeleteAccessLevelResponse> DeleteDatabaseAccessLevelAsync(
+            string username,
+            string dbName);
+
+        /// <summary>
+        /// Fetch the list of databases available to the specified user.
+        /// You need Administrate for the server access level in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="query">Optional query parameters for the request.</param>
+        /// <returns></returns>
+        Task<GetAccessibleDatabasesResponse> GetAccessibleDatabasesAsync(
+            string username,
+            GetAccessibleDatabasesQuery query = null);
+
+        /// <summary>
+        /// Sets the collection access levels of a user for a given database.
+        /// You need the Administrate server access level in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database.</param>
+        /// <param name="collectionName">The name of the collection.</param>
+        /// <param name="body">The body of the request containing the access level.</param>
+        /// <returns></returns>
+        Task<PutAccessLevelResponse> PutCollectionAccessLevelAsync(
+            string username,
+            string dbName,
+            string collectionName,
+            PutAccessLevelBody body);
+
+        /// <summary>
+        /// Gets specific collection access level of a user for a given database.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database.</param>
+        /// <param name="collectionName">The name of the collection.</param>
+        /// <returns></returns>
+        Task<GetAccessLevelResponse> GetCollectionAccessLevelAsync(
+            string username,
+            string dbName,
+            string collectionName);
+
+        /// <summary>
+        /// Clears the collection access levels of a user for a given database.
+        /// As consequence the default collection access level is used.
+        /// If there is no defined default database access level, it defaults to 'No access'.
+        /// You need permission to the '_system' database in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database.</param>
+        /// <param name="collectionName">The name of the collection.</param>
+        /// <returns></returns>
+        Task<DeleteAccessLevelResponse> DeleteCollectionAccessLevelAsync(
+            string username,
+            string dbName,
+            string collectionName);
     }
 }

--- a/arangodb-net-standard/UserApi/Models/DeleteAccessLevelResponse.cs
+++ b/arangodb-net-standard/UserApi/Models/DeleteAccessLevelResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a response returned after clearing
+    /// a database or collection access level.
+    /// </summary>
+    public class DeleteAccessLevelResponse : ResponseBase
+    {
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/DeleteUserResponse.cs
+++ b/arangodb-net-standard/UserApi/Models/DeleteUserResponse.cs
@@ -1,11 +1,9 @@
-﻿using System.Net;
-
-namespace ArangoDBNetStandard.UserApi.Models
+﻿namespace ArangoDBNetStandard.UserApi.Models
 {
-    public class DeleteUserResponse
+    /// <summary>
+    /// Represents a response returned after deleting a user.
+    /// </summary>
+    public class DeleteUserResponse : ResponseBase
     {
-        public bool Error { get; set; }
-
-        public HttpStatusCode Code { get; set; }
     }
 }

--- a/arangodb-net-standard/UserApi/Models/GetAccessLevelResponse.cs
+++ b/arangodb-net-standard/UserApi/Models/GetAccessLevelResponse.cs
@@ -1,0 +1,14 @@
+﻿namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a response returned after fetching
+    /// a database or collection access level.
+    /// </summary>
+    public class GetAccessLevelResponse : ResponseBase
+    {
+        /// <summary>
+        /// The access level for the specified database or collection.
+        /// </summary>
+        public string Result { get; set; }
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/GetAccessibleDatabasesQuery.cs
+++ b/arangodb-net-standard/UserApi/Models/GetAccessibleDatabasesQuery.cs
@@ -1,0 +1,27 @@
+﻿namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents query parameters used when fetching the list of databases
+    /// available to a user.
+    /// </summary>
+    public class GetAccessibleDatabasesQuery
+    {
+        /// <summary>
+        /// Whether to return the full set of access levels
+        /// for all databases and all collections.
+        /// </summary>
+        public bool? Full { get; set; }
+
+        internal string ToQueryString()
+        {
+            if (Full != null)
+            {
+                return "full=" + Full.ToString().ToLower();
+            }
+            else
+            {
+                return "";
+            }
+        }
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/GetAccessibleDatabasesResponse.cs
+++ b/arangodb-net-standard/UserApi/Models/GetAccessibleDatabasesResponse.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a response returned after listing
+    /// the databases accesible by a user.
+    /// </summary>
+    public class GetAccessibleDatabasesResponse : ResponseBase
+    {
+        /// <summary>
+        /// Contains the databases names as keys,
+        /// and the associated privileges for the database as <see cref="string"/> values.
+        /// In case you specified <see cref="GetAccessibleDatabasesQuery.Full"/>,
+        /// it will contain <see cref="object"/> values with the permissions for the databases
+        /// ('permission') as well as the permissions for the collections ('collections').
+        /// </summary>
+        /// <remarks>
+        /// The type of the full <see cref="object"/> values will depend on the serializer used.
+        /// When using the default <see cref="Serialization.JsonNetApiClientSerialization"/>,
+        /// values will be <see cref="Newtonsoft.Json.Linq.JObject"/>.
+        /// </remarks>
+        public Dictionary<string, object> Result { get; set; }
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/PutAccessLevelBody.cs
+++ b/arangodb-net-standard/UserApi/Models/PutAccessLevelBody.cs
@@ -1,0 +1,16 @@
+﻿namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a request body to set database or collection access level.
+    /// </summary>
+    public class PutAccessLevelBody
+    {
+        /// <summary>
+        /// The access level to set.
+        /// Use "rw" to set the collection level access to 'Read/Write'.
+        /// Use "ro" to set the collection level access to 'Read Only'.
+        /// Use "none" to set the collection level access to 'No access'.
+        /// </summary>
+        public string Grant { get; set; }
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/PutAccessLevelResponse.cs
+++ b/arangodb-net-standard/UserApi/Models/PutAccessLevelResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a response returned after setting
+    /// a database or collection access level.
+    /// </summary>
+    public class PutAccessLevelResponse : ResponseBase
+    {
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/ResponseBase.cs
+++ b/arangodb-net-standard/UserApi/Models/ResponseBase.cs
@@ -1,0 +1,20 @@
+﻿using System.Net;
+
+namespace ArangoDBNetStandard.UserApi.Models
+{
+    /// <summary>
+    /// Represents a common response class for user API operations.
+    /// </summary>
+    public class ResponseBase
+    {
+        /// <summary>
+        /// Indicates whether an error occurred (false in this case).
+        /// </summary>
+        public bool Error { get; set; }
+
+        /// <summary>
+        /// The HTTP status code.
+        /// </summary>
+        public HttpStatusCode Code { get; set; }
+    }
+}

--- a/arangodb-net-standard/UserApi/Models/UserResponseBase.cs
+++ b/arangodb-net-standard/UserApi/Models/UserResponseBase.cs
@@ -5,9 +5,9 @@ namespace ArangoDBNetStandard.UserApi.Models
 {
     /// <summary>
     /// Represents a common response class with user information
-    /// returned after performing an operation.
+    /// returned after performing a user operation.
     /// </summary>
-    public class UserResponseBase
+    public class UserResponseBase : ResponseBase
     {
         /// <summary>
         /// The name of the user.
@@ -23,15 +23,5 @@ namespace ArangoDBNetStandard.UserApi.Models
         /// Object with arbitrary extra data about the user.
         /// </summary>
         public Dictionary<string, object> Extra { get; set; }
-
-        /// <summary>
-        /// Indicates whether an error occurred (false in this case).
-        /// </summary>
-        public bool Error { get; set; }
-
-        /// <summary>
-        /// The HTTP status code.
-        /// </summary>
-        public HttpStatusCode Code { get; set; }
     }
 }

--- a/arangodb-net-standard/UserApi/UserApiClient.cs
+++ b/arangodb-net-standard/UserApi/UserApiClient.cs
@@ -153,5 +153,194 @@ namespace ArangoDBNetStandard.UserApi
                 throw await GetApiErrorException(response);
             }
         }
+
+        /// <summary>
+        /// Sets the database access levels of a user for a given database.
+        /// You need the Administrate server access level in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database.</param>
+        /// <param name="body">The body of the request containing the access level.</param>
+        /// <returns></returns>
+        public virtual async Task<PutAccessLevelResponse> PutDatabaseAccessLevelAsync(
+            string username,
+            string dbName,
+            PutAccessLevelBody body)
+        {
+            string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
+                + "/database/" + WebUtility.UrlEncode(dbName);
+            var content = GetContent(body, true, true);
+            using (var response = await _client.PutAsync(uri, content))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<PutAccessLevelResponse>(stream);
+                }
+                throw await GetApiErrorException(response);
+            }
+        }
+
+        /// <summary>
+        /// Gets specific database access level for a user.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database to query.</param>
+        /// <param name="body">The body of the request containing the access level.</param>
+        /// <returns></returns>
+        public virtual async Task<GetAccessLevelResponse> GetDatabaseAccessLevelAsync(
+            string username,
+            string dbName)
+        {
+            string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
+                + "/database/" + WebUtility.UrlEncode(dbName);
+            using (var response = await _client.GetAsync(uri))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<GetAccessLevelResponse>(stream);
+                }
+                throw await GetApiErrorException(response);
+            }
+        }
+
+        /// <summary>
+        /// Clears the database access levels of a user for a given database.
+        /// As consequence the default database access level is used.
+        /// If there is no defined default database access level, it defaults to 'No access'.
+        /// You need permission to the '_system' database in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database.</param>
+        /// <returns></returns>
+        public virtual async Task<DeleteAccessLevelResponse> DeleteDatabaseAccessLevelAsync(
+            string username,
+            string dbName)
+        {
+            string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
+                + "/database/" + WebUtility.UrlEncode(dbName);
+            using (var response = await _client.DeleteAsync(uri))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<DeleteAccessLevelResponse>(stream);
+                }
+                throw await GetApiErrorException(response);
+            }
+        }
+
+        /// <summary>
+        /// Fetch the list of databases available to the specified user.
+        /// You need Administrate for the server access level in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="query">Optional query parameters for the request.</param>
+        /// <returns></returns>
+        public virtual async Task<GetAccessibleDatabasesResponse> GetAccessibleDatabasesAsync(
+            string username,
+            GetAccessibleDatabasesQuery query = null)
+        {
+            string uri = _userApiPath + "/" + WebUtility.UrlEncode(username) + "/database";
+            if (query != null)
+            {
+                uri += '?' + query.ToQueryString();
+            }
+            using (var response = await _client.GetAsync(uri))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<GetAccessibleDatabasesResponse>(stream);
+                }
+                throw await GetApiErrorException(response);
+            }
+        }
+
+        /// <summary>
+        /// Sets the collection access levels of a user for a given database.
+        /// You need the Administrate server access level in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database.</param>
+        /// <param name="collectionName">The name of the collection.</param>
+        /// <param name="body">The body of the request containing the access level.</param>
+        /// <returns></returns>
+        public virtual async Task<PutAccessLevelResponse> PutCollectionAccessLevelAsync(
+            string username,
+            string dbName,
+            string collectionName,
+            PutAccessLevelBody body)
+        {
+            string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
+                + "/database/" + WebUtility.UrlEncode(dbName) + "/" +
+                WebUtility.UrlEncode(collectionName);
+            var content = GetContent(body, true, true);
+            using (var response = await _client.PutAsync(uri, content))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<PutAccessLevelResponse>(stream);
+                }
+                throw await GetApiErrorException(response);
+            }
+        }
+
+        /// <summary>
+        /// Gets specific collection access level of a user for a given database.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database.</param>
+        /// <param name="collectionName">The name of the collection.</param>
+        /// <returns></returns>
+        public virtual async Task<GetAccessLevelResponse> GetCollectionAccessLevelAsync(
+            string username,
+            string dbName,
+            string collectionName)
+        {
+            string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
+                + "/database/" + WebUtility.UrlEncode(dbName) + "/" +
+                WebUtility.UrlEncode(collectionName);
+            using (var response = await _client.GetAsync(uri))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<GetAccessLevelResponse>(stream);
+                }
+                throw await GetApiErrorException(response);
+            }
+        }
+
+        /// <summary>
+        /// Clears the collection access levels of a user for a given database.
+        /// As consequence the default collection access level is used.
+        /// If there is no defined default database access level, it defaults to 'No access'.
+        /// You need permission to the '_system' database in order to execute this REST call.
+        /// </summary>
+        /// <param name="username">The name of the user.</param>
+        /// <param name="dbName">The name of the database.</param>
+        /// <param name="collectionName">The name of the collection.</param>
+        /// <returns></returns>
+        public virtual async Task<DeleteAccessLevelResponse> DeleteCollectionAccessLevelAsync(
+            string username,
+            string dbName,
+            string collectionName)
+        {
+            string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
+                + "/database/" + WebUtility.UrlEncode(dbName) + "/" +
+                WebUtility.UrlEncode(collectionName);
+            using (var response = await _client.DeleteAsync(uri))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    return DeserializeJsonFromStream<DeleteAccessLevelResponse>(stream);
+                }
+                throw await GetApiErrorException(response);
+            }
+        }
     }
 }


### PR DESCRIPTION
fix #282

Implemented the following methods:

- PutDatabaseAccessLevelAsync
- GetDatabaseAccessLevelAsync
- DeleteDatabaseAccessLevelAsync
- GetAccessibleDatabasesAsync
- PutCollectionAccessLevelAsync
- GetCollectionAccessLevelAsync
- DeleteCollectionAccessLevelAsync

Also added related data models and unit tests.

I would like to draw attention on the following endpoint: `GET /_api/user/{user}/database/`, represented by `GetAccessibleDatabasesAsync` and the response `GetAccessibleDatabasesResponse`.

https://www.arangodb.com/docs/stable/http/user-management.html#list-the-accessible-databases-for-a-user

The type of the values in the `result` property of the response will change if the query parameter `full` is provided.

Example without full:
```
"result" : { 
    "_system" : "rw" 
  } 
```

Example with full:
```
"result" : { 
    "_system" : { 
      "permission" : "rw", 
      "collections" : { 
        "_fishbowl" : "undefined", 
        "*" : "undefined" 
      } 
   }
}
```

So I used `Dictionary<string, object>` for the property type in the C# response model, with a doc comment to explain what to expect.