### PR TITLE
Provide ability to override options used to serialize

### DIFF
--- a/arangodb-net-standard.Test/Serialization/JsonNetApiClientSerializationTest.cs
+++ b/arangodb-net-standard.Test/Serialization/JsonNetApiClientSerializationTest.cs
@@ -22,7 +22,7 @@ namespace ArangoDBNetStandardTest.Serialization
 
             var serialization = new JsonNetApiClientSerialization();
 
-            byte[] jsonBytes = serialization.Serialize(model, true, true);
+            byte[] jsonBytes = serialization.Serialize(model, ApiClientSerializationContentType.PostGraph);
 
             string jsonString = Encoding.UTF8.GetString(jsonBytes);
 
@@ -42,7 +42,7 @@ namespace ArangoDBNetStandardTest.Serialization
             };
             var serialization = new JsonNetApiClientSerialization();
 
-            byte[] jsonBytes = serialization.Serialize(body, true, true);
+            byte[] jsonBytes = serialization.Serialize(body, ApiClientSerializationContentType.PostCursor);
 
             string jsonString = Encoding.UTF8.GetString(jsonBytes);
 
@@ -65,7 +65,7 @@ namespace ArangoDBNetStandardTest.Serialization
 
             var serialization = new JsonNetApiClientSerialization();
 
-            byte[] jsonBytes = serialization.Serialize(body, true, true);
+            byte[] jsonBytes = serialization.Serialize(body, ApiClientSerializationContentType.PostTransaction);
 
             string jsonString = Encoding.UTF8.GetString(jsonBytes);
 
@@ -88,7 +88,7 @@ namespace ArangoDBNetStandardTest.Serialization
             };
             var serialization = new JsonNetApiClientSerialization();
 
-            byte[] jsonBytes = serialization.Serialize(body, true, true);
+            byte[] jsonBytes = serialization.Serialize(body, ApiClientSerializationContentType.PostCursor);
 
             string jsonString = Encoding.UTF8.GetString(jsonBytes);
 
@@ -109,7 +109,7 @@ namespace ArangoDBNetStandardTest.Serialization
 
             var serialization = new JsonNetApiClientSerialization();
 
-            byte[] jsonBytes = serialization.Serialize(body, true, true);
+            byte[] jsonBytes = serialization.Serialize(body, ApiClientSerializationContentType.PostTransaction);
 
             string jsonString = Encoding.UTF8.GetString(jsonBytes);
 

--- a/arangodb-net-standard/ApiClientBase.cs
+++ b/arangodb-net-standard/ApiClientBase.cs
@@ -66,14 +66,11 @@ namespace ArangoDBNetStandard
             }
         }
 
-        protected byte[] GetContent<T>(T item, bool useCamelCasePropertyNames, bool ignoreNullValues)
+        protected byte[] GetContent<T>(T item, ApiClientSerializationContentType contentType)
         {
             try
             {
-                return _serialization.Serialize<T>(
-                    item,
-                    useCamelCasePropertyNames,
-                    ignoreNullValues);
+                return _serialization.Serialize(item, contentType);
             }
             catch (Exception e)
             {

--- a/arangodb-net-standard/AqlFunctionApi/AqlFunctionApiClient.cs
+++ b/arangodb-net-standard/AqlFunctionApi/AqlFunctionApiClient.cs
@@ -53,7 +53,7 @@ namespace ArangoDBNetStandard.AqlFunctionApi
         /// <returns></returns>
         public virtual async Task<PostAqlFunctionResponse> PostAqlFunctionAsync(PostAqlFunctionBody body)
         {
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PostAqlFunction);
 
             using (var response = await _transport.PostAsync(_apiPath, content))
             {

--- a/arangodb-net-standard/AuthApi/AuthApiClient.cs
+++ b/arangodb-net-standard/AuthApi/AuthApiClient.cs
@@ -60,7 +60,7 @@ namespace ArangoDBNetStandard.AuthApi
         /// <returns>Object containing the encoded JWT token value.</returns>
         public virtual async Task<JwtTokenResponse> GetJwtTokenAsync(JwtTokenRequestBody body)
         {
-            byte[] content = GetContent(body, true, false);
+            byte[] content = GetContent(body, ApiClientSerializationContentType.GetJwtToken);
             using (var response = await _client.PostAsync("/_open/auth", content))
             {
                 if (response.IsSuccessStatusCode)

--- a/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
@@ -52,7 +52,7 @@ namespace ArangoDBNetStandard.CollectionApi
             {
                 uriString += "?" + options.ToQueryString();
             }
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PostCollection);
             using (var response = await _transport.PostAsync(uriString, content))
             {
                 var stream = await response.Content.ReadAsStreamAsync();
@@ -188,7 +188,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <returns></returns>
         public virtual async Task<RenameCollectionResponse> RenameCollectionAsync(string collectionName, RenameCollectionBody body)
         {
-            var content = GetContent(body, true, false);
+            var content = GetContent(body, ApiClientSerializationContentType.RenameCollection);
             using (var response = await _transport.PutAsync(_collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/rename", content))
             {
                 if (response.IsSuccessStatusCode)
@@ -229,7 +229,7 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <returns></returns>
         public virtual async Task<PutCollectionPropertyResponse> PutCollectionPropertyAsync(string collectionName, PutCollectionPropertyBody body)
         {
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PutCollection);
             using (var response = await _transport.PutAsync(_collectionApiPath + "/" + collectionName + "/properties", content))
             {
                 if (response.IsSuccessStatusCode)

--- a/arangodb-net-standard/CursorApi/CursorApiClient.cs
+++ b/arangodb-net-standard/CursorApi/CursorApiClient.cs
@@ -88,7 +88,7 @@ namespace ArangoDBNetStandard.CursorApi
         /// <returns></returns>
         public virtual async Task<CursorResponse<T>> PostCursorAsync<T>(PostCursorBody postCursorBody)
         {
-            var content = GetContent(postCursorBody, true, true);
+            var content = GetContent(postCursorBody, ApiClientSerializationContentType.PostCursor);
             using (var response = await _client.PostAsync(_cursorApiPath, content))
             {
                 if (response.IsSuccessStatusCode)

--- a/arangodb-net-standard/DatabaseApi/DatabaseApiClient.cs
+++ b/arangodb-net-standard/DatabaseApi/DatabaseApiClient.cs
@@ -53,7 +53,7 @@ namespace ArangoDBNetStandard.DatabaseApi
         /// <returns></returns>
         public virtual async Task<PostDatabaseResponse> PostDatabaseAsync(PostDatabaseBody request)
         {
-            var content = GetContent(request, true, true);
+            var content = GetContent(request, ApiClientSerializationContentType.PostDatabase);
             using (var response = await _client.PostAsync(_databaseApiPath, content))
             {
                 if (response.IsSuccessStatusCode)

--- a/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
+++ b/arangodb-net-standard/DocumentApi/DocumentApiClient.cs
@@ -63,7 +63,7 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 uriString += "?" + query.ToQueryString();
             }
-            var content = GetContent(document, false, false);
+            var content = GetContent(document, ApiClientSerializationContentType.PostDocument);
             using (var response = await _client.PostAsync(uriString, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -93,7 +93,7 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 uriString += "?" + query.ToQueryString();
             }
-            var content = GetContent(documents, false, false);
+            var content = GetContent(documents, ApiClientSerializationContentType.PostDocuments);
             using (var response = await _client.PostAsync(uriString, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -130,7 +130,7 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 uri += "?" + query.ToQueryString();
             }
-            var content = GetContent(documents, false, false);
+            var content = GetContent(documents, ApiClientSerializationContentType.PutDocuments);
             using (var response = await _client.PutAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -170,7 +170,7 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 uri += "?" + opts.ToQueryString();
             }
-            var content = GetContent(doc, false, false);
+            var content = GetContent(doc, ApiClientSerializationContentType.PutDocument);
             using (var response = await _client.PutAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -251,7 +251,7 @@ namespace ArangoDBNetStandard.DocumentApi
         {
             string uri = $"{_docApiPath}/{WebUtility.UrlEncode(collectionName)}?onlyget=true";
 
-            var content = GetContent(selectors, false, true);
+            var content = GetContent(selectors, ApiClientSerializationContentType.GetDocuments);
 
             using (var response = await _client.PutAsync(uri, content))
             {
@@ -394,7 +394,7 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 uri += "?" + query.ToQueryString();
             }
-            var content = GetContent(selectors, false, false);
+            var content = GetContent(selectors, ApiClientSerializationContentType.DeleteDocuments);
             using (var response = await _client.DeleteAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -445,7 +445,7 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 uri += "?" + query.ToQueryString();
             }
-            var content = GetContent(patches, false, false);
+            var content = GetContent(patches, ApiClientSerializationContentType.PatchDocuments);
             using (var response = await _client.PatchAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -522,7 +522,7 @@ namespace ArangoDBNetStandard.DocumentApi
             {
                 uriString += "?" + query.ToQueryString();
             }
-            var content = GetContent(body, false, false);
+            var content = GetContent(body, ApiClientSerializationContentType.PatchDocument);
             using (var response = await _client.PatchAsync(uriString, content))
             {
                 if (response.IsSuccessStatusCode)

--- a/arangodb-net-standard/GraphApi/GraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/GraphApiClient.cs
@@ -64,7 +64,7 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
 
-            var content = GetContent(postGraphBody, true, true);
+            var content = GetContent(postGraphBody, ApiClientSerializationContentType.PostGraph);
 
             using (var response = await _transport.PostAsync(uri, content))
             {
@@ -102,11 +102,11 @@ namespace ArangoDBNetStandard.GraphApi
         /// <summary>
         /// Deletes an existing graph object by name.
         /// Optionally all collections not used by other
-        /// graphs can be deleted as well, using <see cref = "DeleteGraphQuery" ></ see >.
+        /// graphs can be deleted as well, using <see cref = "DeleteGraphQuery" ></see >.
         /// DELETE /_api/gharial/{graph-name}
         /// </summary>
         /// <param name="graphName"></param>
-        /// <param name="body"></param>
+        /// <param name="query"></param>
         /// <returns></returns>
         public virtual async Task<DeleteGraphResponse> DeleteGraphAsync(string graphName, DeleteGraphQuery query = null)
         {
@@ -201,7 +201,7 @@ namespace ArangoDBNetStandard.GraphApi
             string graphName,
             PostEdgeDefinitionBody body)
         {
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PostEdgeDefinition);
 
             string uri = _graphApiPath + "/" + WebUtility.UrlEncode(graphName) + "/edge";
 
@@ -230,7 +230,7 @@ namespace ArangoDBNetStandard.GraphApi
         {
             string uri = _graphApiPath + '/' + WebUtility.UrlEncode(graphName) + "/vertex";
 
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PostVertexCollection);
 
             using (var response = await _transport.PostAsync(uri, content))
             {
@@ -265,7 +265,7 @@ namespace ArangoDBNetStandard.GraphApi
             {
                 uri += "?" + query.ToQueryString();
             }
-            var content = GetContent(vertex, false, false);
+            var content = GetContent(vertex, ApiClientSerializationContentType.PostVertex);
             using (var response = await _transport.PostAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -363,7 +363,7 @@ namespace ArangoDBNetStandard.GraphApi
             T edge,
             PostEdgeQuery query = null)
         {
-            var content = GetContent(edge, false, false);
+            var content = GetContent(edge, ApiClientSerializationContentType.PostEdge);
 
             string uri = _graphApiPath + "/" + WebUtility.UrlEncode(graphName) +
                 "/edge/" + WebUtility.UrlEncode(collectionName);
@@ -497,6 +497,7 @@ namespace ArangoDBNetStandard.GraphApi
             }
         }
 
+        /// <summary>
         /// Gets a vertex from the given collection.
         /// GET/_api/gharial/{graph}/vertex/{collection}/{vertex}
         /// </summary>
@@ -662,7 +663,7 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
 
-            var content = GetContent(body, false, false);
+            var content = GetContent(body, ApiClientSerializationContentType.PatchVertex);
             using (var response = await _transport.PatchAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -725,7 +726,7 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
 
-            var content = GetContent(edge, false, false);
+            var content = GetContent(edge,ApiClientSerializationContentType.PutEdge);
             using (var response = await _transport.PutAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -761,7 +762,7 @@ namespace ArangoDBNetStandard.GraphApi
             {
                 uriString += "?" + query.ToQueryString();
             }
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PutEdgeDefinition);
             using (var response = await _transport.PutAsync(uriString, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -827,7 +828,7 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
 
-            var content = GetContent(edge, true, true);
+            var content = GetContent(edge, ApiClientSerializationContentType.PatchEdge);
             using (var response = await _transport.PatchAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -889,7 +890,7 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
 
-            var content = GetContent(vertex, true, true);
+            var content = GetContent(vertex, ApiClientSerializationContentType.PutVertex);
             using (var response = await _transport.PutAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)

--- a/arangodb-net-standard/Serialization/ApiClientSerialization.cs
+++ b/arangodb-net-standard/Serialization/ApiClientSerialization.cs
@@ -1,0 +1,98 @@
+﻿using System.IO;
+
+namespace ArangoDBNetStandard.Serialization
+{
+    /// <summary>
+    /// The Api client serilization abastract class.
+    /// Used as a base to implement custom serilizations.
+    /// </summary>
+    public abstract class ApiClientSerialization : IApiClientSerialization
+    {
+        /// <summary>
+        /// Serializes the specified object to a sequence of bytes,
+        /// override this method to implement the custom serializer action the given object.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to serialize.</typeparam>
+        /// <param name="item">The object to serialize.</param>
+        /// <param name="options">The serialization content type.</param>
+        /// <returns></returns>
+        protected abstract byte[] SerializeItem<T>(T item, ApiClientSerializationOptions options);
+
+        /// <summary>
+        /// Gets the serizilzation options for the given content type.
+        /// Override this method in order to implement custom serialization
+        /// options, otherwise these defaults options will be
+        /// applied.
+        /// </summary>
+        /// <param name="contentType">The content type.</param>
+        /// <returns></returns>
+        protected virtual ApiClientSerializationOptions GetSerializationOptions(ApiClientSerializationContentType contentType)
+        {
+            switch(contentType){
+                case ApiClientSerializationContentType.PostCursor:
+                case ApiClientSerializationContentType.PostAqlFunction:
+                case ApiClientSerializationContentType.PostCollection:
+                case ApiClientSerializationContentType.PostGraph:
+                case ApiClientSerializationContentType.PostEdgeDefinition:
+                case ApiClientSerializationContentType.PutEdgeDefinition:
+                case ApiClientSerializationContentType.PatchEdge:
+                case ApiClientSerializationContentType.PutVertex:
+                case ApiClientSerializationContentType.PostTransaction:
+                case ApiClientSerializationContentType.PostUser:
+                case ApiClientSerializationContentType.PutUser:
+                case ApiClientSerializationContentType.PatchUser:
+                case ApiClientSerializationContentType.PutCollectionAccessLevel:
+                case ApiClientSerializationContentType.PutDatabaseAccessLevel:
+                case ApiClientSerializationContentType.PostDatabase:
+                case ApiClientSerializationContentType.PutCollection:
+                case ApiClientSerializationContentType.PostVertexCollection:
+                    return new ApiClientSerializationOptions(true, true);
+
+                case ApiClientSerializationContentType.PostDocument:
+                case ApiClientSerializationContentType.PostDocuments:
+                case ApiClientSerializationContentType.PutDocument:
+                case ApiClientSerializationContentType.PutDocuments:
+                case ApiClientSerializationContentType.DeleteDocuments:
+                case ApiClientSerializationContentType.PatchDocuments:
+                case ApiClientSerializationContentType.PatchDocument:
+                case ApiClientSerializationContentType.PostVertex:
+                case ApiClientSerializationContentType.PostEdge:
+                case ApiClientSerializationContentType.PatchVertex:
+                case ApiClientSerializationContentType.PutEdge:
+                    return new ApiClientSerializationOptions(false, false);
+
+                case ApiClientSerializationContentType.GetJwtToken:
+                case ApiClientSerializationContentType.RenameCollection:
+                    return new ApiClientSerializationOptions(true, false);
+
+                case ApiClientSerializationContentType.GetDocuments:
+                    return new ApiClientSerializationOptions(false, true);
+            }
+
+            throw new System.Exception("No options found for the specific serialization content type");
+        }
+
+        /// <summary>
+        /// Deserializes the data structure contained by the specified stream
+        /// into an instance of the specified type.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to deserialize to.</typeparam>
+        /// <param name="stream">The stream containing the JSON structure to deserialize.</param>
+        /// <returns></returns>
+        public abstract T DeserializeFromStream<T>(Stream stream);
+
+        /// <summary>
+        /// Serializes the specified object to a sequence of bytes,
+        /// following the provided rules for camel case property name and null value handling.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to serialize.</typeparam>
+        /// <param name="item">The object to serialize.</param>
+        /// <param name="contentType">The serialization content type.</param>
+        /// <returns></returns>
+        public byte[] Serialize<T>(T item, ApiClientSerializationContentType contentType)
+        {
+            var options = GetSerializationOptions(contentType);
+            return SerializeItem(item, options);
+        }
+    }
+}

--- a/arangodb-net-standard/Serialization/ApiClientSerializationContentType.cs
+++ b/arangodb-net-standard/Serialization/ApiClientSerializationContentType.cs
@@ -1,0 +1,168 @@
+﻿namespace ArangoDBNetStandard.Serialization
+{
+    /// <summary>
+    /// The API client content type enum.
+    /// </summary>
+    public enum ApiClientSerializationContentType
+    {
+        /// <summary>
+        /// Post graph.
+        /// </summary>
+        PostGraph,
+
+        /// <summary>
+        /// Post edge definition.
+        /// </summary>
+        PostEdgeDefinition,
+
+        /// <summary>
+        /// Post edge.
+        /// </summary>
+        PostEdge,
+
+        /// <summary>
+        /// Put edge.
+        /// </summary>
+        PutEdge,
+
+        /// <summary>
+        /// Patch edge.
+        /// </summary>
+        PatchEdge,
+
+        /// <summary>
+        /// Put Edge Definition.
+        /// </summary>
+        PutEdgeDefinition,
+
+        /// <summary>
+        /// Post vertex.
+        /// </summary>
+        PostVertex,
+
+        /// <summary>
+        /// Patch vertex.
+        /// </summary>
+        PatchVertex,
+
+        /// <summary>
+        /// Put vertex.
+        /// </summary>
+        PutVertex,
+
+        /// <summary>
+        /// Post vertex collection.
+        /// </summary>
+        PostVertexCollection,
+
+        /// <summary>
+        /// Get documents.
+        /// </summary>
+        GetDocuments,
+
+        /// <summary>
+        /// Delete documents.
+        /// </summary>
+        DeleteDocuments,
+
+        /// <summary>
+        /// Post AQL funtion.
+        /// </summary>
+        PostAqlFunction,
+
+        /// <summary>
+        /// Get the JWT token.
+        /// </summary>
+        GetJwtToken,
+
+        /// <summary>
+        /// Post collection.
+        /// </summary>
+        PostCollection,
+
+        /// <summary>
+        /// Rename collection.
+        /// </summary>
+        RenameCollection,
+
+        /// <summary>
+        /// Put collection.
+        /// </summary>
+        PutCollection,
+
+        /// <summary>
+        /// Post Cursor.
+        /// </summary>
+        PostCursor,
+
+        /// <summary>
+        /// Post database.
+        /// </summary>
+        PostDatabase,
+
+        /// <summary>
+        /// Post document.
+        /// </summary>
+        PostDocument,
+
+        /// <summary>
+        /// Post documents.
+        /// </summary>
+        PostDocuments,
+
+        /// <summary>
+        /// Patch document.
+        /// </summary>
+        PatchDocument,
+
+        /// <summary>
+        /// Patch documents.
+        /// </summary>
+        PatchDocuments,
+
+        /// <summary>
+        /// Put document.
+        /// </summary>
+        PutDocument,
+
+        /// <summary>
+        /// Put document.
+        /// </summary>
+        PutDocuments,
+
+        /// <summary>
+        /// Delete document.
+        /// </summary>
+        DeleteDocument,
+
+        /// <summary>
+        /// Post transaction.
+        /// </summary>
+        PostTransaction,
+
+        /// <summary>
+        /// Post user.
+        /// </summary>
+        PostUser,
+
+        /// <summary>
+        /// Put user.
+        /// </summary>
+        PutUser,
+
+        /// <summary>
+        /// Patch user.
+        /// </summary>
+        PatchUser,
+
+        /// <summary>
+        /// Put database access level.
+        /// </summary>
+        PutDatabaseAccessLevel,
+
+        /// <summary>
+        /// Put collection access level.
+        /// </summary>
+        PutCollectionAccessLevel
+    }
+}

--- a/arangodb-net-standard/Serialization/ApiClientSerializationOptions.cs
+++ b/arangodb-net-standard/Serialization/ApiClientSerializationOptions.cs
@@ -1,0 +1,30 @@
+﻿namespace ArangoDBNetStandard.Serialization
+{
+    /// <summary>
+    /// The API client serilization options class.
+    /// </summary>
+    public class ApiClientSerializationOptions
+    {
+        /// <summary>
+        /// Use camlel case if true, otherwise depends on
+        /// the action will be implemented in the serializer.
+        /// </summary>
+        public bool UseCamelCasePropertyNames { get; }
+        
+        /// <summary>
+        /// True to ignore values, otherwise false.
+        /// </summary>
+        public bool IgnoreNullValues { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="useCamelCasePropertyNames"></param>
+        /// <param name="ignoreNullValues"></param>
+        public ApiClientSerializationOptions(bool useCamelCasePropertyNames, bool ignoreNullValues)
+        {
+            UseCamelCasePropertyNames = useCamelCasePropertyNames;
+            IgnoreNullValues = ignoreNullValues;
+        }
+    }
+}

--- a/arangodb-net-standard/Serialization/IApiClientSerialization.cs
+++ b/arangodb-net-standard/Serialization/IApiClientSerialization.cs
@@ -22,9 +22,8 @@ namespace ArangoDBNetStandard.Serialization
         /// </summary>
         /// <typeparam name="T">The type of the object to serialize.</typeparam>
         /// <param name="item">The object to serialize.</param>
-        /// <param name="useCamelCasePropertyNames">Whether property names should be camel cased.</param>
-        /// <param name="ignoreNullValues">Whether null values should be ignored.</param>
+        /// <param name="contentType">The serialization content type.</param>
         /// <returns></returns>
-        byte[] Serialize<T>(T item, bool useCamelCasePropertyNames, bool ignoreNullValues);
+        byte[] Serialize<T>(T item, ApiClientSerializationContentType contentType);
     }
 }

--- a/arangodb-net-standard/Serialization/JsonNetApiClientSerialization.cs
+++ b/arangodb-net-standard/Serialization/JsonNetApiClientSerialization.cs
@@ -1,9 +1,5 @@
 ﻿using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Text;
 
 namespace ArangoDBNetStandard.Serialization
@@ -11,7 +7,7 @@ namespace ArangoDBNetStandard.Serialization
     /// <summary>
     /// Implements a <see cref="IApiClientSerialization"/> that uses Json.NET.
     /// </summary>
-    public class JsonNetApiClientSerialization : IApiClientSerialization
+    public class JsonNetApiClientSerialization : ApiClientSerialization
     {
         /// <summary>
         /// Deserializes the JSON structure contained by the specified stream
@@ -20,7 +16,7 @@ namespace ArangoDBNetStandard.Serialization
         /// <typeparam name="T">The type of the object to deserialize to.</typeparam>
         /// <param name="stream">The stream containing the JSON structure to deserialize.</param>
         /// <returns></returns>
-        public virtual T DeserializeFromStream<T>(Stream stream)
+        public override T DeserializeFromStream<T>(Stream stream)
         {
             if (stream == null || stream.CanRead == false)
             {
@@ -44,20 +40,16 @@ namespace ArangoDBNetStandard.Serialization
         /// </summary>
         /// <typeparam name="T">The type of the object to serialize.</typeparam>
         /// <param name="item">The object to serialize.</param>
-        /// <param name="useCamelCasePropertyNames">Whether property names should be camel cased (camelCase).</param>
-        /// <param name="ignoreNullValues">Whether null values should be ignored.</param>
+        /// <param name="serializationOptions"></param>
         /// <returns></returns>
-        public virtual byte[] Serialize<T>(
-            T item,
-            bool useCamelCasePropertyNames,
-            bool ignoreNullValues)
+        protected override byte[] SerializeItem<T>(T item, ApiClientSerializationOptions serializationOptions)
         {
             var jsonSettings = new JsonSerializerSettings
             {
-                NullValueHandling = ignoreNullValues ? NullValueHandling.Ignore : NullValueHandling.Include
+                NullValueHandling = serializationOptions.IgnoreNullValues ? NullValueHandling.Ignore : NullValueHandling.Include
             };
 
-            if (useCamelCasePropertyNames)
+            if (serializationOptions.UseCamelCasePropertyNames)
             {
                 jsonSettings.ContractResolver = new CamelCasePropertyNamesExceptDictionaryContractResolver();
             }

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -52,7 +52,7 @@ namespace ArangoDBNetStandard.TransactionApi
         public virtual async Task<PostTransactionResponse<T>> PostTransactionAsync<T>(
             PostTransactionBody body)
         {
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PostTransaction);
             using (var response = await _client.PostAsync(_transactionApiPath, content))
             {
                 var stream = await response.Content.ReadAsStreamAsync();

--- a/arangodb-net-standard/UserApi/UserApiClient.cs
+++ b/arangodb-net-standard/UserApi/UserApiClient.cs
@@ -55,7 +55,7 @@ namespace ArangoDBNetStandard.UserApi
         /// <returns></returns>
         public virtual async Task<PostUserResponse> PostUserAsync(PostUserBody body)
         {
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PostUser);
             using (var response = await _client.PostAsync(_userApiPath, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -78,7 +78,7 @@ namespace ArangoDBNetStandard.UserApi
         public virtual async Task<PutUserResponse> PutUserAsync(string username, PutUserBody body)
         {
             string uri = _userApiPath + '/' + username;
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PutUser);
             using (var response = await _client.PutAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -101,7 +101,7 @@ namespace ArangoDBNetStandard.UserApi
         public virtual async Task<PatchUserResponse> PatchUserAsync(string username, PatchUserBody body)
         {
             string uri = _userApiPath + '/' + username;
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PatchUser);
             using (var response = await _client.PatchAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -169,7 +169,7 @@ namespace ArangoDBNetStandard.UserApi
         {
             string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
                 + "/database/" + WebUtility.UrlEncode(dbName);
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PutDatabaseAccessLevel);
             using (var response = await _client.PutAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)
@@ -276,7 +276,7 @@ namespace ArangoDBNetStandard.UserApi
             string uri = _userApiPath + "/" + WebUtility.UrlEncode(username)
                 + "/database/" + WebUtility.UrlEncode(dbName) + "/" +
                 WebUtility.UrlEncode(collectionName);
-            var content = GetContent(body, true, true);
+            var content = GetContent(body, ApiClientSerializationContentType.PutCollectionAccessLevel);
             using (var response = await _client.PutAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)


### PR DESCRIPTION
Why : Trying to use IApiClientSerialization in order to write an ApiClinetSerializer that uses System.Text.Json was a little bit problematic, since it expects that the serializer has attributes like Newton.Json or similar behaviour. This causes issues and the serialized data ended up having a mix of Pascal and Camel casing + in Sytem.Text.Json there is not a 1-1 correspondence when it comes to attributes etc.
Making a more flexible Interface so we can choose the options for the serialisation can help with the implementation of the interface but also give the user the ability to choose the serialization options for different actions. Don't think that any random combination of rules will work though.
There are at least couple of issues that mention the camel/pascal naming policy. 
This PR hopes to give some flexibility to the user on these options for specific types of content. 

Also in this PR we do not change the options behaviour for different content types, this should behave exactly as the original code. 