### PR TITLE
Make cluster-only graph properties optional in response.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,9 +81,9 @@ jobs:
     docker:
       - image: mcr.microsoft.com/dotnet/core/sdk:2.2
         environment:
-          ARANGO_HOST: adb3_6_4
-      - image: arangodb/arangodb:3.6.4
-        name: adb3_6_4
+          ARANGO_HOST: adb3_6_8
+      - image: arangodb/arangodb:3.6.8
+        name: adb3_6_8
         environment:
           ARANGO_ROOT_PASSWORD: root
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
             - "test-arangodb-3_5"
       - "test-arangodb-3_7":
           requires:
-            - "test-arangodb-3_6"
+            - build
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ workflows:
       - "test-arangodb-3_6":
           requires:
             - "test-arangodb-3_5"
+      - "test-arangodb-3_7":
+          requires:
+            - "test-arangodb-3_6"
 
 jobs:
   build:
@@ -81,6 +84,25 @@ jobs:
           ARANGO_HOST: adb3_6_4
       - image: arangodb/arangodb:3.6.4
         name: adb3_6_4
+        environment:
+          ARANGO_ROOT_PASSWORD: root
+    steps:
+      - attach_workspace:
+          # Must be absolute path or relative path from working_directory
+          at: ~/
+      - run:
+          name: Test
+          command:
+            dotnet test
+
+  "test-arangodb-3_7":
+    working_directory: ~/arangodb-net-standard
+    docker:
+      - image: mcr.microsoft.com/dotnet/core/sdk:2.2
+        environment:
+          ARANGO_HOST: adb3_7_3
+      - image: arangodb/arangodb:3.7.3
+        name: adb3_7_3
         environment:
           ARANGO_ROOT_PASSWORD: root
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
       - run:
           name: Test
           command:
-            dotnet test
+            dotnet test -c Release
 
   "test-arangodb-3_7":
     working_directory: ~/arangodb-net-standard

--- a/arangodb-net-standard.Test/GraphApi/GraphApiClientTest.cs
+++ b/arangodb-net-standard.Test/GraphApi/GraphApiClientTest.cs
@@ -36,12 +36,11 @@ namespace ArangoDBNetStandardTest.GraphApi
             var graph = graphsResult.Graphs.First(x => x._key == _fixture.TestGraph);
             Assert.NotEmpty(graph.EdgeDefinitions);
             Assert.Empty(graph.OrphanCollections);
-            Assert.Equal(1, graph.NumberOfShards);
-            Assert.Equal(1, graph.ReplicationFactor);
-            Assert.False(graph.IsSmart);
             Assert.Equal(_fixture.TestGraph, graph._key);
             Assert.Equal("_graphs/" + _fixture.TestGraph, graph._id);
             Assert.NotNull(graph._rev);
+
+            // check smart properties once tests can run on enterprise edition
         }
 
         [Fact]
@@ -93,12 +92,11 @@ namespace ArangoDBNetStandardTest.GraphApi
             Assert.Equal("_graphs/" + _fixture.TestGraph, response.Graph._id);
             Assert.NotEmpty(response.Graph.EdgeDefinitions);
             Assert.Empty(response.Graph.OrphanCollections);
-            Assert.Equal(1, response.Graph.NumberOfShards);
-            Assert.Equal(1, response.Graph.ReplicationFactor);
-            Assert.False(response.Graph.IsSmart);
             Assert.Equal(_fixture.TestGraph, response.Graph._key);
             Assert.Equal("_graphs/" + _fixture.TestGraph, response.Graph._id);
             Assert.NotNull(response.Graph._rev);
+
+            // check smart properties once tests can run on enterprise edition
         }
 
         [Fact]
@@ -292,7 +290,6 @@ namespace ArangoDBNetStandardTest.GraphApi
             Assert.Equal(tempGraph, response.Graph.Name);
             Assert.Equal("_graphs/" + tempGraph, response.Graph._id);
             Assert.NotNull(response.Graph._rev);
-            Assert.False(response.Graph.IsSmart);
             Assert.Empty(response.Graph.OrphanCollections);
         }
 

--- a/arangodb-net-standard/GraphApi/GraphApiClient.cs
+++ b/arangodb-net-standard/GraphApi/GraphApiClient.cs
@@ -51,6 +51,9 @@ namespace ArangoDBNetStandard.GraphApi
         /// Creates a new graph in the graph module.
         /// POST /_api/gharial
         /// </summary>
+        /// <remarks>
+        /// The creation of a graph requires the name of the graph and a definition of its edges.
+        /// </remarks>
         /// <param name="postGraphBody">The information of the graph to create.</param>
         /// <param name="query">Optional query parameters of the request.</param>
         /// <returns></returns>
@@ -370,7 +373,7 @@ namespace ArangoDBNetStandard.GraphApi
             string collectionName,
             T edge,
             PostEdgeQuery query = null,
-            ApiClientSerializationOptions serializationOptions  = null)
+            ApiClientSerializationOptions serializationOptions = null)
         {
             var content = GetContent(edge, serializationOptions);
 
@@ -735,7 +738,7 @@ namespace ArangoDBNetStandard.GraphApi
                 uri += "?" + query.ToQueryString();
             }
 
-            var content = GetContent(edge, new ApiClientSerializationOptions(false,false));
+            var content = GetContent(edge, new ApiClientSerializationOptions(false, false));
             using (var response = await _transport.PutAsync(uri, content))
             {
                 if (response.IsSuccessStatusCode)

--- a/arangodb-net-standard/GraphApi/Models/GraphResult.cs
+++ b/arangodb-net-standard/GraphApi/Models/GraphResult.cs
@@ -37,9 +37,13 @@ namespace ArangoDBNetStandard.GraphApi.Models
         public string SmartGraphAttribute { get; set; }
 
         /// <summary>
-        /// The replication factor used for every new collection in the graph.
+        /// The replication factor used for every new collection in the graph (Enterprise Edition only).
         /// </summary>
-        public int ReplicationFactor { get; set; }
+        /// <remarks>
+        /// Returned only in a cluster setup since ArangoDB 3.7,
+        /// as this property is not meaningful in a single server.
+        /// </remarks>
+        public int? ReplicationFactor { get; set; }
 
         /// <summary>
         /// A list of additional vertex collections.
@@ -50,12 +54,20 @@ namespace ArangoDBNetStandard.GraphApi.Models
         /// <summary>
         /// Number of shards created for every new collection in the graph.
         /// </summary>
-        public int NumberOfShards { get; set; }
+        /// <remarks>
+        /// Returned only in a cluster setup since ArangoDB 3.7,
+        /// as this property is not meaningful in a single server.
+        /// </remarks>
+        public int? NumberOfShards { get; set; }
 
         /// <summary>
         /// Indicates whether the graph is a SmartGraph (Enterprise Edition only).
         /// </summary>
-        public bool IsSmart { get; set; }
+        /// <remarks>
+        /// Returned only in a cluster setup since ArangoDB 3.7,
+        /// as this property is not meaningful in a single server.
+        /// </remarks>
+        public bool? IsSmart { get; set; }
 
         /// <summary>
         /// A list of definitions for the relations of the graph.

--- a/arangodb-net-standard/GraphApi/Models/PostGraphBody.cs
+++ b/arangodb-net-standard/GraphApi/Models/PostGraphBody.cs
@@ -2,16 +2,41 @@
 
 namespace ArangoDBNetStandard.GraphApi.Models
 {
+    /// <summary>
+    /// Represents a request body to create a named graph.
+    /// </summary>
+    /// <remarks>
+    /// The creation of a graph requires the name of the graph and a definition of its edges.
+    /// </remarks>
     public class PostGraphBody
     {
+        /// <summary>
+        /// Name of the graph.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// List of definitions for the relations of the graph.
+        /// </summary>
         public List<EdgeDefinition> EdgeDefinitions { get; set; }
 
+        /// <summary>
+        /// (Optional) List of additional vertex collections.
+        /// Documents within these collections do not have edges within this graph.
+        /// </summary>
         public List<string> OrphanCollections { get; set; }
 
+        /// <summary>
+        /// (Optional) Defines if the created graph should be smart (Enterprise Edition only).
+        /// </summary>
+        /// <remarks>
+        /// (cluster only)
+        /// </remarks>
         public bool? IsSmart { get; set; }
 
+        /// <summary>
+        /// (Optional) Defines options for creating collections within this graph.
+        /// </summary>
         public PostGraphOptions Options { get; set; }
     }
 }

--- a/arangodb-net-standard/GraphApi/Models/PostGraphOptions.cs
+++ b/arangodb-net-standard/GraphApi/Models/PostGraphOptions.cs
@@ -10,9 +10,10 @@
         /// It is required if creating a SmartGraph.
         /// Every vertex in this SmartGraph has to have this attribute.
         /// Cannot be modified later.
+        /// (Enterprise Edition only).
         /// </summary>
         /// <remarks>
-        /// Only has effect in Enterprise Edition.
+        /// (cluster only)
         /// </remarks>
         public string SmartGraphAttribute { get; set; }
 
@@ -20,11 +21,18 @@
         /// The number of shards that is used for every collection within this graph.
         /// Cannot be modified later.
         /// </summary>
+        /// <remarks>
+        /// (cluster only)
+        /// </remarks>
         public int NumberOfShards { get; set; }
 
         /// <summary>
-        /// The replication factor used when initially creating collections for this graph.
+        /// The replication factor used when initially creating collections for this graph
+        /// (Enterprise Edition only).
         /// </summary>
+        /// <remarks>
+        /// (cluster only)
+        /// </remarks>
         public int ReplicationFactor { get; set; }
     }
 }


### PR DESCRIPTION
fix #303

Based on #298