### PR TITLE
Proposal: implicit HttpClient reuse

### DIFF
--- a/arangodb-net-standard/ArangoDBClient.cs
+++ b/arangodb-net-standard/ArangoDBClient.cs
@@ -71,7 +71,7 @@ namespace ArangoDBNetStandard
 
         /// <summary>
         /// Create an instance of <see cref="ArangoDBClient"/> from an existing
-        /// <see cref="HttpClient"/> instance, using the default JSON serialization.
+        /// <see cref="HttpClientConfig"/> instance, using the default JSON serialization.
         /// </summary>
         /// <param name="clientConfig"></param>
         public ArangoDBClient(HttpClientConfig clientConfig)

--- a/arangodb-net-standard/ArangoDBClient.cs
+++ b/arangodb-net-standard/ArangoDBClient.cs
@@ -73,10 +73,10 @@ namespace ArangoDBNetStandard
         /// Create an instance of <see cref="ArangoDBClient"/> from an existing
         /// <see cref="HttpClient"/> instance, using the default JSON serialization.
         /// </summary>
-        /// <param name="client"></param>
-        public ArangoDBClient(HttpClient client)
+        /// <param name="clientConfig"></param>
+        public ArangoDBClient(HttpClientConfig clientConfig)
         {
-            _transport = new HttpApiTransport(client, HttpContentType.Json);
+            _transport = new HttpApiTransport(clientConfig, HttpContentType.Json);
 
             var serialization = new JsonNetApiClientSerialization();
 

--- a/arangodb-net-standard/Transport/Http/HttpApiTransport.cs
+++ b/arangodb-net-standard/Transport/Http/HttpApiTransport.cs
@@ -21,7 +21,7 @@ namespace ArangoDBNetStandard.Transport.Http
         private readonly HttpClientConfig _clientConfig;
 
         /// <summary>
-        /// Create <see cref="HttpApiTransport"/> from an existing <see cref="HttpClient"/> instance.
+        /// Create <see cref="HttpApiTransport"/> from an existing <see cref="HttpClientConfig"/> instance.
         /// </summary>
         /// <param name="clientConfig">Existing HTTP client configuration instance.</param>
         /// <param name="contentType">Content type to use in requests.

--- a/arangodb-net-standard/Transport/Http/HttpClientConfig.cs
+++ b/arangodb-net-standard/Transport/Http/HttpClientConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -74,19 +75,11 @@ namespace ArangoDBNetStandard.Transport.Http
             _key["auth"] = $"jwt,{jwt}";
         }
 
-        static Dictionary<string, HttpClient> _pool = new Dictionary<string, HttpClient>();
+        static ConcurrentDictionary<string, HttpClient> _pool = new ConcurrentDictionary<string, HttpClient>();
 
         internal HttpClient Build()
         {
-            HttpClient client;
-            var key = string.Join(";", _key);
-            lock (_pool) {
-                if (!_pool.TryGetValue(key, out client)) {
-                    client = Create();
-                    _pool[key] = client;
-                }
-            }
-            return client;
+            return _pool.GetOrAdd(string.Join(";", _key), _ => Create());
         }
     }
 }

--- a/arangodb-net-standard/Transport/Http/HttpClientConfig.cs
+++ b/arangodb-net-standard/Transport/Http/HttpClientConfig.cs
@@ -76,7 +76,7 @@ namespace ArangoDBNetStandard.Transport.Http
 
         static Dictionary<string, HttpClient> _pool = new Dictionary<string, HttpClient>();
 
-        public HttpClient Build()
+        internal HttpClient Build()
         {
             HttpClient client;
             var key = string.Join(";", _key);

--- a/arangodb-net-standard/Transport/Http/HttpClientConfig.cs
+++ b/arangodb-net-standard/Transport/Http/HttpClientConfig.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Linq;
+
+namespace ArangoDBNetStandard.Transport.Http
+{
+    public class HttpClientConfig
+    {
+        public Uri BaseAddress {
+            set {
+                _config += client => client.BaseAddress = value;
+                _key["baseaddress"] = value.ToString();
+            }
+        }
+        public MediaTypeHeaderValue ContentType { 
+            get {
+                return new MediaTypeHeaderValue(_contentTypeMap[_contentType]);
+            }
+        }
+
+        public void UseContentType(HttpContentType contentType)
+        {
+            _contentType = contentType;
+            _config += client =>
+            {
+                client.DefaultRequestHeaders.Accept.Clear();
+                client.DefaultRequestHeaders.Accept.Add(
+                    new MediaTypeWithQualityHeaderValue(_contentTypeMap[_contentType]));
+            };
+            _key["type"] = contentType.ToString();
+        }
+
+        private Dictionary<string, string> _key = new Dictionary<string, string>();
+        private Action<HttpClient> _config = _ => { };
+        private Action<HttpClient> _auth = _ => { };
+
+        private HttpClient Create() 
+        {
+            var cli = new HttpClient();
+            _config(cli);
+            _auth(cli);
+            return cli;
+        }
+
+        private HttpContentType _contentType;
+
+        private static readonly Dictionary<HttpContentType, string> _contentTypeMap =
+            new Dictionary<HttpContentType, string>
+            {
+                [HttpContentType.Json] = "application/json",
+                [HttpContentType.VPack] = "application/x-velocypack"
+            };
+
+        public void SetBasicAuth(string username, string password)
+        {
+            _auth = client =>
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                    "Basic",
+                    Convert.ToBase64String(
+                        Encoding.ASCII.GetBytes($"{username}:{password}")));
+            _key["auth"] = $"basic,{username}:{password}";
+        }
+
+        public void SetJwtToken(string jwt)
+        {
+            _auth = client =>
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
+                   "bearer",
+                   jwt);
+            };
+            _key["auth"] = $"jwt,{jwt}";
+        }
+
+        static Dictionary<string, HttpClient> _pool = new Dictionary<string, HttpClient>();
+
+        public HttpClient Build()
+        {
+            HttpClient client;
+            var key = string.Join(";", _key);
+            if (!_pool.TryGetValue(key, out client)) {
+                client = Create();
+                _pool[key] = client;
+            }
+            return client;
+        }
+    }
+}

--- a/arangodb-net-standard/Transport/Http/HttpClientConfig.cs
+++ b/arangodb-net-standard/Transport/Http/HttpClientConfig.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
-using System.Linq;
 
 namespace ArangoDBNetStandard.Transport.Http
 {
@@ -81,9 +80,11 @@ namespace ArangoDBNetStandard.Transport.Http
         {
             HttpClient client;
             var key = string.Join(";", _key);
-            if (!_pool.TryGetValue(key, out client)) {
-                client = Create();
-                _pool[key] = client;
+            lock (_pool) {
+                if (!_pool.TryGetValue(key, out client)) {
+                    client = Create();
+                    _pool[key] = client;
+                }
             }
             return client;
         }


### PR DESCRIPTION
These changes create a "pool" of HttpClients, identified by their options and authentication, so that they can be reused only at each proper context (this way you will not need to make changes that require awareness on client code).

Originated by https://arangodb.atlassian.net/browse/ES-846 