### PR TITLE
Implement Stream Transaction Api.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Test
           command:
-            dotnet test -c Release
+            dotnet test -c Release --filter Transactions!=Stream
             
   "test-arangodb-3_5":
     working_directory: ~/arangodb-net-standard

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - run:
           name: Test
           command:
-            dotnet test -c Release --filter Transactions!=Stream
+            dotnet test -c Release --filter Feature!=StreamTransaction
             
   "test-arangodb-3_5":
     working_directory: ~/arangodb-net-standard

--- a/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
+++ b/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
@@ -32,11 +32,11 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// Tests that the stream transaction gets aborted successfully.
         /// </summary>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task AbortTransaction_ShouldSucceed()
         {
             // Begin a new transaction.
-            var beginTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+            var beginTransaction = await _adb.Transaction.BeginTransaction(
                 new StreamTransactionBody
                 {
                     Collections = new PostTransactionRequestCollections
@@ -46,8 +46,7 @@ namespace ArangoDBNetStandardTest.TransactionApi
                 });
 
             // Abort the transaction.
-            var abortTransaction =
-                await _adb.Transaction.AbortTransaction<StreamTransactionResult>(beginTransaction.Result.Id);
+            var abortTransaction = await _adb.Transaction.AbortTransaction(beginTransaction.Result.Id);
 
             // Check for the correct transaction status.
             Assert.Equal(StreamTransactionStatus.Aborted, abortTransaction.Result.Status);
@@ -58,11 +57,11 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// </summary>
         /// <exception cref="ApiErrorException">With ErrorNum 1653 if the transaction cannot be aborted.</exception>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task AbortTransaction_ShouldThrowException_WhenTheTransactionCannotBeAborted()
         {
             // Begin a new transaction to create a document.
-            var beginTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+            var beginTransaction = await _adb.Transaction.BeginTransaction(
                 new StreamTransactionBody
                 {
                     Collections = new PostTransactionRequestCollections
@@ -72,11 +71,11 @@ namespace ArangoDBNetStandardTest.TransactionApi
                 });
 
             // Commit the transaction.
-            await _adb.Transaction.CommitTransaction<StreamTransactionResult>(beginTransaction.Result.Id);
+            await _adb.Transaction.CommitTransaction(beginTransaction.Result.Id);
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
             {
                 // Abort the transaction with the same transaction Id.
-                await _adb.Transaction.AbortTransaction<object>(beginTransaction.Result.Id);
+                await _adb.Transaction.AbortTransaction(beginTransaction.Result.Id);
             });
 
             // Check for the correct error number.
@@ -88,12 +87,12 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// </summary>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task AbortTransaction_ShouldThrowException_WhenTheTransactionIsNotFound()
         {
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
             {
-                await _adb.Transaction.AbortTransaction<object>("Some Bogus Transaction Id");
+                await _adb.Transaction.AbortTransaction("Some Bogus Transaction Id");
             });
 
             // Check for the correct error number.
@@ -104,11 +103,11 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// Tests that when the existing collections are used to begin a transaction, the stream transaction is running.
         /// </summary>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task BeginTransaction_ShouldSucceed()
         {
             // Begin a transaction.
-            var beginTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+            var beginTransaction = await _adb.Transaction.BeginTransaction(
                 new StreamTransactionBody
                 {
                     Collections = new PostTransactionRequestCollections
@@ -126,18 +125,19 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// </summary>
         /// <exception cref="ApiErrorException">With ErrorNum 1203 if the collection is not found.</exception>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task BeginTransaction_ShouldThrowException_WhenReferring_To_A_NonExisting_Collection()
         {
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
-                await _adb.Transaction.BeginTransaction<object>(new StreamTransactionBody
-                {
-                    Collections = new PostTransactionRequestCollections
+                await _adb.Transaction.BeginTransaction(
+                    new StreamTransactionBody
                     {
-                        Read = new[] { "SomeCollection" },
-                        Write = new[] { "TestCollection1" },
-                    },
-                }));
+                        Collections = new PostTransactionRequestCollections
+                        {
+                            Read = new[] { "SomeCollection" },
+                            Write = new[] { "TestCollection1" },
+                        },
+                    }));
 
             // Check for the correct error number.
             Assert.Equal(1203, ex.ApiError.ErrorNum);
@@ -148,12 +148,10 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// </summary>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction body is missing.</exception>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task BeginTransaction_ShouldThrowException_WhenTransactionBodyIsMissing()
         {
-            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
-                await _adb.Transaction.BeginTransaction<object>(null)
-            );
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () => await _adb.Transaction.BeginTransaction(null));
 
             // Check for the correct error number.
             Assert.Equal(10, ex.ApiError.ErrorNum);
@@ -163,11 +161,11 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// Tests that the stream transaction gets committed successfully.
         /// </summary>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task CommitTransaction_ShouldSucceed()
         {
             // Begin a new transaction.
-            var beginTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+            var beginTransaction = await _adb.Transaction.BeginTransaction(
                 new StreamTransactionBody
                 {
                     Collections = new PostTransactionRequestCollections
@@ -177,7 +175,7 @@ namespace ArangoDBNetStandardTest.TransactionApi
                 });
 
             // Commit the transaction.
-            var result = await _adb.Transaction.CommitTransaction<StreamTransactionResult>(beginTransaction.Result.Id);
+            var result = await _adb.Transaction.CommitTransaction(beginTransaction.Result.Id);
 
             // Check for the correct transaction status.
             Assert.Equal(StreamTransactionStatus.Committed, result.Result.Status);
@@ -188,11 +186,11 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// </summary>
         /// <exception cref="ApiErrorException">With ErrorNum 1653 if the transaction cannot be committed.</exception>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task CommitTransaction_ShouldThrowException_WhenTheTransactionCannotBeCommitted()
         {
             // Begin a new transaction to create a document.
-            var beginTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+            var beginTransaction = await _adb.Transaction.BeginTransaction(
                 new StreamTransactionBody
                 {
                     Collections = new PostTransactionRequestCollections
@@ -202,11 +200,11 @@ namespace ArangoDBNetStandardTest.TransactionApi
                 });
 
             // Abort the transaction.
-            await _adb.Transaction.AbortTransaction<StreamTransactionResult>(beginTransaction.Result.Id);
+            await _adb.Transaction.AbortTransaction(beginTransaction.Result.Id);
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
             {
                 // Commit the transaction with the same transaction Id.
-                await _adb.Transaction.CommitTransaction<object>(beginTransaction.Result.Id);
+                await _adb.Transaction.CommitTransaction(beginTransaction.Result.Id);
             });
 
             // Check for the correct error number.
@@ -218,12 +216,12 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// </summary>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task CommitTransaction_ShouldThrowException_WhenTheTransactionIsNotFound()
         {
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
             {
-                await _adb.Transaction.CommitTransaction<object>("Some Bogus Transaction Id");
+                await _adb.Transaction.CommitTransaction("Some Bogus Transaction Id");
             });
 
             // Check for the correct error number.
@@ -234,11 +232,11 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// Tests that all running transactions are returned successfully.
         /// </summary>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task GetAllRunningTransactions_ShouldSucceed()
         {
             // Begin the first transaction.
-            var firstTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+            var firstTransaction = await _adb.Transaction.BeginTransaction(
                 new StreamTransactionBody
                 {
                     Collections = new PostTransactionRequestCollections
@@ -248,7 +246,7 @@ namespace ArangoDBNetStandardTest.TransactionApi
                 });
 
             // Begin the second transaction.
-            var secondTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+            var secondTransaction = await _adb.Transaction.BeginTransaction(
                 new StreamTransactionBody
                 {
                     Collections = new PostTransactionRequestCollections
@@ -269,7 +267,7 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// Tests that when there are no running transactions, an empty list of <see cref="Transaction"/> is returned.
         /// </summary>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task GetAllRunningTransactions_ShouldSucceed_WhenThereAreNoRunningTransactions()
         {
             // Get all running transactions.
@@ -284,11 +282,11 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// Tests that the status of a transaction is returned successfully.
         /// </summary>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task GetTransactionStatus_ShouldSucceed()
         {
             // Begin the transaction.
-            var firstTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+            var firstTransaction = await _adb.Transaction.BeginTransaction(
                 new StreamTransactionBody
                 {
                     Collections = new PostTransactionRequestCollections
@@ -298,8 +296,7 @@ namespace ArangoDBNetStandardTest.TransactionApi
                 });
 
             // Get the transaction status.
-            var transaction =
-                await _adb.Transaction.GetTransactionStatus<StreamTransactionResult>(firstTransaction.Result.Id);
+            var transaction = await _adb.Transaction.GetTransactionStatus(firstTransaction.Result.Id);
 
             // Check for the correct transaction status.
             Assert.Equal(firstTransaction.Result.Status, transaction.Result.Status);
@@ -310,12 +307,12 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// </summary>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>
         [Fact]
-        [Trait("Transactions", "Stream")]
+        [Trait("Feature", "StreamTransaction")]
         public async Task GetTransactionStatus_ShouldThrowException_WhenTheTransctionIdIsNotFound()
         {
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
             {
-                await _adb.Transaction.GetTransactionStatus<object>("Some Bogus Transaction Id");
+                await _adb.Transaction.GetTransactionStatus("Some Bogus Transaction Id");
             });
 
             // Check for the correct error number.

--- a/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
+++ b/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
@@ -53,36 +53,6 @@ namespace ArangoDBNetStandardTest.TransactionApi
         }
 
         /// <summary>
-        /// Test that an exception is thrown when trying to abort a transaction that has already been committed.
-        /// </summary>
-        /// <exception cref="ApiErrorException">With ErrorNum 1653 if the transaction cannot be aborted.</exception>
-        [Fact]
-        [Trait("Feature", "StreamTransaction")]
-        public async Task AbortTransaction_ShouldThrowException_WhenTheTransactionCannotBeAborted()
-        {
-            // Begin a new transaction to create a document.
-            var beginTransaction = await _adb.Transaction.BeginTransaction(
-                new StreamTransactionBody
-                {
-                    Collections = new PostTransactionRequestCollections
-                    {
-                        Write = new[] { "TestCollection1" },
-                    },
-                });
-
-            // Commit the transaction.
-            await _adb.Transaction.CommitTransaction(beginTransaction.Result.Id);
-            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
-            {
-                // Abort the transaction with the same transaction Id.
-                await _adb.Transaction.AbortTransaction(beginTransaction.Result.Id);
-            });
-
-            // Check for the correct error number.
-            Assert.Equal(1653, ex.ApiError.ErrorNum);
-        }
-
-        /// <summary>
         /// Test that an exception is thrown when trying to abort a transaction that does not exist.
         /// </summary>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>
@@ -126,7 +96,7 @@ namespace ArangoDBNetStandardTest.TransactionApi
         /// <exception cref="ApiErrorException">With ErrorNum 1203 if the collection is not found.</exception>
         [Fact]
         [Trait("Feature", "StreamTransaction")]
-        public async Task BeginTransaction_ShouldThrowException_WhenReferring_To_A_NonExisting_Collection()
+        public async Task BeginTransaction_ShouldThrowException_WhenReferringToANonExistingCollection()
         {
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
                 await _adb.Transaction.BeginTransaction(
@@ -141,20 +111,6 @@ namespace ArangoDBNetStandardTest.TransactionApi
 
             // Check for the correct error number.
             Assert.Equal(1203, ex.ApiError.ErrorNum);
-        }
-
-        /// <summary>
-        /// Tests that when there is no transaction body, the stream transaction does not begin.
-        /// </summary>
-        /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction body is missing.</exception>
-        [Fact]
-        [Trait("Feature", "StreamTransaction")]
-        public async Task BeginTransaction_ShouldThrowException_WhenTransactionBodyIsMissing()
-        {
-            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () => await _adb.Transaction.BeginTransaction(null));
-
-            // Check for the correct error number.
-            Assert.Equal(10, ex.ApiError.ErrorNum);
         }
 
         /// <summary>
@@ -179,36 +135,6 @@ namespace ArangoDBNetStandardTest.TransactionApi
 
             // Check for the correct transaction status.
             Assert.Equal(StreamTransactionStatus.Committed, result.Result.Status);
-        }
-
-        /// <summary>
-        /// Test that an exception is thrown when trying to commit a transaction that has already been aborted.
-        /// </summary>
-        /// <exception cref="ApiErrorException">With ErrorNum 1653 if the transaction cannot be committed.</exception>
-        [Fact]
-        [Trait("Feature", "StreamTransaction")]
-        public async Task CommitTransaction_ShouldThrowException_WhenTheTransactionCannotBeCommitted()
-        {
-            // Begin a new transaction to create a document.
-            var beginTransaction = await _adb.Transaction.BeginTransaction(
-                new StreamTransactionBody
-                {
-                    Collections = new PostTransactionRequestCollections
-                    {
-                        Write = new[] { "TestCollection1" },
-                    },
-                });
-
-            // Abort the transaction.
-            await _adb.Transaction.AbortTransaction(beginTransaction.Result.Id);
-            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
-            {
-                // Commit the transaction with the same transaction Id.
-                await _adb.Transaction.CommitTransaction(beginTransaction.Result.Id);
-            });
-
-            // Check for the correct error number.
-            Assert.Equal(1653, ex.ApiError.ErrorNum);
         }
 
         /// <summary>

--- a/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
+++ b/arangodb-net-standard.Test/TransactionApi/TransactionApiClientTest.cs
@@ -1,16 +1,26 @@
-﻿using ArangoDBNetStandard;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using ArangoDBNetStandard;
 using ArangoDBNetStandard.DocumentApi.Models;
 using ArangoDBNetStandard.TransactionApi.Models;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace ArangoDBNetStandardTest.TransactionApi
 {
-    public class TransactionApiClientTest: IClassFixture<TransactionApiClientTestFixture>
+    /// <summary>
+    /// The Transaction Api Client test class.
+    /// </summary>
+    public class TransactionApiClientTest : IClassFixture<TransactionApiClientTestFixture>
     {
-        private ArangoDBClient _adb;
+        /// <summary>
+        /// The Arango database client.
+        /// </summary>
+        private readonly ArangoDBClient _adb;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransactionApiClientTest"/> class.
+        /// </summary>
+        /// <param name="fixture">The test repository fixture with the blank database etc.</param>
         public TransactionApiClientTest(TransactionApiClientTestFixture fixture)
         {
             _adb = fixture.ArangoDBClient;
@@ -18,14 +28,212 @@ namespace ArangoDBNetStandardTest.TransactionApi
             _adb.Collection.TruncateCollectionAsync(fixture.TestCollection2).Wait();
         }
 
+        /// <summary>
+        /// Tests that the stream transaction gets aborted successfully.
+        /// </summary>
         [Fact]
-        public async Task PostTransaction_ShouldSucceed()
+        public async Task AbortTransaction_ShouldSucceed()
         {
-            await _adb.Document.PostDocumentAsync("TestCollection2",
+            var beginTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+                new StreamTransactionBody
+                {
+                    Collections = new PostTransactionRequestCollections
+                    {
+                        Write = new[] { "TestCollection2" },
+                    },
+                });
+
+            var dummyCollectionUpdate = await _adb.Document.PostDocumentAsync(
+                "TestCollection2",
                 new
                 {
                     _key = "names",
-                     value = new[] { "world", "love" }
+                    value = new[] { "world", "love" },
+                });
+
+            // Abort the transaction.
+            var result =
+                await _adb.Transaction.AbortTransaction<StreamTransactionResult>(beginTransaction.Result.Id);
+
+            // Check for the correct transaction status.
+            Assert.Equal(StreamTransactionStatus.Aborted, result.Result.Status);
+
+            // Check the collection is not updated yet.
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _adb.Document.GetDocumentAsync<object>(dummyCollectionUpdate._id);
+            });
+
+            Assert.Equal(1202, ex.ApiError.ErrorNum);
+        }
+
+        /// <summary>
+        /// Tests that when the existing collections are used to begin a transaction, the stream transaction is running.
+        /// </summary>
+        [Fact]
+        public async Task BeginTransaction_ShouldSucceed()
+        {
+            var result = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+                new StreamTransactionBody
+                {
+                    Collections = new PostTransactionRequestCollections
+                    {
+                        Write = new[] { "TestCollection2" },
+                    },
+                });
+
+            // Check for the correct transaction status.
+            Assert.Equal(StreamTransactionStatus.Running, result.Result.Status);
+
+            var dummyCollectionUpdate = await _adb.Document.PostDocumentAsync(
+            "TestCollection2",
+            new
+            {
+                _key = "names",
+                value = new[] { "world", "love" },
+            });
+
+            // Check the collection is not updated yet.
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _adb.Document.GetDocumentAsync<object>(dummyCollectionUpdate._id);
+            });
+
+            Assert.Equal(1202, ex.ApiError.ErrorNum);
+        }
+
+        /// <summary>
+        /// Tests that when referring to a non existing collection to transact, the stream transaction does not begin.
+        /// </summary>
+        /// <exception cref="ApiErrorException">With ErrorNum 1203 if the collection is not found.</exception>
+        [Fact]
+        public async Task BeginTransaction_ShouldThrowException_WhenReferring_To_A_NonExisting_Collection()
+        {
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+                await _adb.Transaction.BeginTransaction<object>(new StreamTransactionBody
+                {
+                    Collections = new PostTransactionRequestCollections
+                    {
+                        Read = new[] { "SomeCollection" },
+                        Write = new[] { "TestCollection2" },
+                    },
+                }));
+
+            Assert.Equal(1203, ex.ApiError.ErrorNum);
+        }
+
+        /// <summary>
+        /// Tests that the stream transaction gets committed successfully.
+        /// </summary>
+        [Fact]
+        public async Task CommitTransaction_ShouldSucceed()
+        {
+            var beginTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+                new StreamTransactionBody
+                {
+                    Collections = new PostTransactionRequestCollections
+                    {
+                        Write = new[] { "TestCollection2" },
+                    },
+                });
+
+            var dummyCollectionUpdate = await _adb.Document.PostDocumentAsync(
+                    "TestCollection2",
+                    new
+                    {
+                        _key = "names",
+                        value = new[] { "world", "love" },
+                    });
+
+            // Check the collection is not updated yet.
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
+            {
+                await _adb.Document.GetDocumentAsync<object>(dummyCollectionUpdate._id);
+            });
+
+            Assert.Equal(1202, ex.ApiError.ErrorNum);
+
+            // Commit a transaction.
+            var result =
+                await _adb.Transaction.CommitTransaction<StreamTransactionResult>(beginTransaction.Result.Id);
+
+            // Check for the correct transaction status.
+            Assert.Equal(StreamTransactionStatus.Committed, result.Result.Status);
+
+            // Check that the collection is now updated.
+            var latestCollectionUpdate = await _adb.Document.GetDocumentAsync<object>(dummyCollectionUpdate._id);
+
+            // Check that the document exists.
+            Assert.NotNull(latestCollectionUpdate);
+        }
+
+        /// <summary>
+        /// Tests that all running transactions are returned successfully.
+        /// </summary>
+        [Fact]
+        public async Task GetAllRunningTransactions_ShouldSucceed()
+        {
+            var firstTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+                    new StreamTransactionBody
+                    {
+                        Collections = new PostTransactionRequestCollections
+                        {
+                            Write = new[] { "TestCollection1" },
+                        },
+                    });
+
+            var secondTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+                    new StreamTransactionBody
+                    {
+                        Collections = new PostTransactionRequestCollections
+                        {
+                            Write = new[] { "TestCollection2" },
+                        },
+                    });
+
+            // Get all running transactions.
+            var result = await _adb.Transaction.GetAllRunningTransactions();
+
+            // Check for all the running transactions.
+            Assert.Equal(2, result.Transactions.Count);
+            Assert.Contains(result.Transactions, x => x.State.Equals(StreamTransactionStatus.Running));
+        }
+
+        /// <summary>
+        /// Tests that the status of a transaction is returned successfully.
+        /// </summary>
+        [Fact]
+        public async Task GetTransactionStatus_ShouldSucceed()
+        {
+            var firstTransaction = await _adb.Transaction.BeginTransaction<StreamTransactionResult>(
+                        new StreamTransactionBody
+                        {
+                            Collections = new PostTransactionRequestCollections
+                            {
+                                Write = new[] { "TestCollection1" },
+                            },
+                        });
+
+            // Get the transaction status.
+            var transaction =
+                await _adb.Transaction.GetTransactionStatus<StreamTransactionResult>(firstTransaction.Result.Id);
+
+            // Check for the correct transaction status.
+            Assert.Equal(firstTransaction.Result.Status, transaction.Result.Status);
+        }
+
+        /// <summary>
+        /// Tests that a post JS transaction succeeds.
+        /// </summary>
+        [Fact]
+        public async Task PostTransaction_ShouldSucceed()
+        {
+            await _adb.Document.PostDocumentAsync(
+                "TestCollection2",
+                new
+                {
+                    _key = "names",
+                    value = new[] { "world", "love" },
                 });
 
             var result = await _adb.Transaction.PostTransactionAsync<List<DocumentBase>>(new PostTransactionBody
@@ -45,8 +253,8 @@ namespace ArangoDBNetStandardTest.TransactionApi
                 Collections = new PostTransactionRequestCollections
                 {
                     Read = new[] { "TestCollection2" },
-                    Write = new[] { "TestCollection1" }
-                }
+                    Write = new[] { "TestCollection1" },
+                },
             });
 
             Assert.Equal(2, result.Result.Count);
@@ -58,28 +266,36 @@ namespace ArangoDBNetStandardTest.TransactionApi
             Assert.Equal("Hello, love", (string)doc2.message);
         }
 
+        /// <summary>
+        /// Tests that when the action in JS transaction has syntax error, an exception is thrown.
+        /// </summary>
+        /// <exception cref="ApiErrorException">With ErrorNum 10 missing/invalid action definition for transaction.</exception>
         [Fact]
         public async Task PostTransaction_ShouldThrow_WhenFunctionDefinitionHasSyntaxErrors()
         {
-            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () => 
+            var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
                 await _adb.Transaction.PostTransactionAsync<object>(new PostTransactionBody
                 {
                     Action = "function (params) { syntax error }",
                     Collections = new PostTransactionRequestCollections
                     {
-                        Write = new[] { "test" }
-                    }
+                        Write = new[] { "test" },
+                    },
                 }));
             Assert.Equal(10, ex.ApiError.ErrorNum);
         }
 
+        /// <summary>
+        /// Tests that when there is no collection, an exception is thrown.
+        /// </summary>
+        /// <exception cref="ApiErrorException">With ErrorNum 10 missing/invalid collections definition for transaction.</exception>
         [Fact]
         public async Task PostTransaction_ShouldThrow_WhenWriteCollectionIsNotDeclared()
         {
             var ex = await Assert.ThrowsAsync<ApiErrorException>(async () =>
                 await _adb.Transaction.PostTransactionAsync<object>(new PostTransactionBody
                 {
-                    Action = "function (params) { console.log('This is a test'); }"
+                    Action = "function (params) { console.log('This is a test'); }",
                 }));
             Assert.Equal(10, ex.ApiError.ErrorNum);
         }

--- a/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
@@ -12,55 +12,49 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Abort a stream transaction by DELETE.
         /// </summary>
         /// /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#abort-transaction.
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#abort-transaction
         /// </remarks>
-        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 1653 if the transaction cannot be aborted.
         /// With ErrorNum 10 if the transaction is not found.
         /// </exception>
         /// <returns>Response from ArangoDB after aborting a transaction.</returns>
-        Task<PostTransactionResponse<TStreamTransactionResult>> AbortTransaction<TStreamTransactionResult>(
-            string transactionId);
+        Task<StreamTransactionResponse> AbortTransaction(string transactionId);
 
         /// <summary>
         /// Begin a stream transaction by POST.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#begin-a-transaction.
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#begin-a-transaction
         /// </remarks>
-        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 10 if the <paramref name="body"/> is missing or malformed.
         /// With ErrorNum 1203 if the <paramref name="body"/> contains an unknown collection.
         /// </exception>
         /// <returns>Response from ArangoDB after beginning a transaction.</returns>
-        Task<PostTransactionResponse<TStreamTransactionResult>> BeginTransaction<TStreamTransactionResult>(
-            StreamTransactionBody body);
+        Task<StreamTransactionResponse> BeginTransaction(StreamTransactionBody body);
 
         /// <summary>
         /// Commit a transaction by PUT.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#commit-transaction.
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#commit-transaction
         /// </remarks>
-        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 1653 if the transaction cannot be committed.
         /// With ErrorNum 10 if the transaction is not found.
         /// </exception>
         /// <returns>Response from ArangoDB after committing a transaction.</returns>
-        Task<PostTransactionResponse<TStreamTransactionResult>> CommitTransaction<TStreamTransactionResult>(
-            string transactionId);
+        Task<StreamTransactionResponse> CommitTransaction(string transactionId);
 
         /// <summary>
         /// Get currently running transactions.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-currently-running-transactions.
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-currently-running-transactions
         /// </remarks>
         /// <returns>Response from ArangoDB with all running transactions.</returns>
         Task<StreamTransactions> GetAllRunningTransactions();
@@ -69,14 +63,12 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Get the status of a transaction.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-transaction-status.
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-transaction-status
         /// </remarks>
-        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>
         /// <returns>Response from ArangoDB with the status of a transaction.</returns>
-        Task<PostTransactionResponse<TStreamTransactionResult>> GetTransactionStatus<TStreamTransactionResult>(
-            string transactionId);
+        Task<StreamTransactionResponse> GetTransactionStatus(string transactionId);
 
         /// <summary>
         /// POST a transaction to ArangoDB.

--- a/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
@@ -16,6 +16,10 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </remarks>
         /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <exception cref="ApiErrorException">
+        /// With ErrorNum 1653 if the transaction cannot be aborted.
+        /// With ErrorNum 10 if the transaction is not found.
+        /// </exception>
         /// <returns>Response from ArangoDB after aborting a transaction.</returns>
         Task<PostTransactionResponse<TStreamTransactionResult>> AbortTransaction<TStreamTransactionResult>(
             string transactionId);
@@ -28,6 +32,10 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </remarks>
         /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
+        /// <exception cref="ApiErrorException">
+        /// With ErrorNum 10 if the <paramref name="body"/> is missing or malformed.
+        /// With ErrorNum 1203 if the <paramref name="body"/> contains an unknown collection.
+        /// </exception>
         /// <returns>Response from ArangoDB after beginning a transaction.</returns>
         Task<PostTransactionResponse<TStreamTransactionResult>> BeginTransaction<TStreamTransactionResult>(
             StreamTransactionBody body);
@@ -40,6 +48,10 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </remarks>
         /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <exception cref="ApiErrorException">
+        /// With ErrorNum 1653 if the transaction cannot be committed.
+        /// With ErrorNum 10 if the transaction is not found.
+        /// </exception>
         /// <returns>Response from ArangoDB after committing a transaction.</returns>
         Task<PostTransactionResponse<TStreamTransactionResult>> CommitTransaction<TStreamTransactionResult>(
             string transactionId);
@@ -61,6 +73,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </remarks>
         /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>
         /// <returns>Response from ArangoDB with the status of a transaction.</returns>
         Task<PostTransactionResponse<TStreamTransactionResult>> GetTransactionStatus<TStreamTransactionResult>(
             string transactionId);

--- a/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
@@ -12,7 +12,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Abort a stream transaction by DELETE.
         /// </summary>
         /// /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#abort-transaction
+        /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#abort-transaction
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">
@@ -26,7 +26,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Begin a stream transaction by POST.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#begin-a-transaction
+        /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#begin-a-transaction
         /// </remarks>
         /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
         /// <exception cref="ApiErrorException">
@@ -40,7 +40,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Commit a transaction by PUT.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#commit-transaction
+        /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#commit-transaction
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">
@@ -54,7 +54,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Get currently running transactions.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-currently-running-transactions
+        /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#get-currently-running-transactions
         /// </remarks>
         /// <returns>Response from ArangoDB with all running transactions.</returns>
         Task<StreamTransactions> GetAllRunningTransactions();
@@ -63,7 +63,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Get the status of a transaction.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-transaction-status
+        /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#get-transaction-status
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>

--- a/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/ITransactionApiClient.cs
@@ -1,5 +1,5 @@
-﻿using ArangoDBNetStandard.TransactionApi.Models;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using ArangoDBNetStandard.TransactionApi.Models;
 
 namespace ArangoDBNetStandard.TransactionApi
 {
@@ -8,6 +8,63 @@ namespace ArangoDBNetStandard.TransactionApi
     /// </summary>
     public interface ITransactionApiClient
     {
+        /// <summary>
+        /// Abort a stream transaction by DELETE.
+        /// </summary>
+        /// /// <remarks>
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#abort-transaction.
+        /// </remarks>
+        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
+        /// <param name="transactionId">The transaction identifier.</param>
+        /// <returns>Response from ArangoDB after aborting a transaction.</returns>
+        Task<PostTransactionResponse<TStreamTransactionResult>> AbortTransaction<TStreamTransactionResult>(
+            string transactionId);
+
+        /// <summary>
+        /// Begin a stream transaction by POST.
+        /// </summary>
+        /// <remarks>
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#begin-a-transaction.
+        /// </remarks>
+        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
+        /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
+        /// <returns>Response from ArangoDB after beginning a transaction.</returns>
+        Task<PostTransactionResponse<TStreamTransactionResult>> BeginTransaction<TStreamTransactionResult>(
+            StreamTransactionBody body);
+
+        /// <summary>
+        /// Commit a transaction by PUT.
+        /// </summary>
+        /// <remarks>
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#commit-transaction.
+        /// </remarks>
+        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
+        /// <param name="transactionId">The transaction identifier.</param>
+        /// <returns>Response from ArangoDB after committing a transaction.</returns>
+        Task<PostTransactionResponse<TStreamTransactionResult>> CommitTransaction<TStreamTransactionResult>(
+            string transactionId);
+
+        /// <summary>
+        /// Get currently running transactions.
+        /// </summary>
+        /// <remarks>
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-currently-running-transactions.
+        /// </remarks>
+        /// <returns>Response from ArangoDB with all running transactions.</returns>
+        Task<StreamTransactions> GetAllRunningTransactions();
+
+        /// <summary>
+        /// Get the status of a transaction.
+        /// </summary>
+        /// <remarks>
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-transaction-status.
+        /// </remarks>
+        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
+        /// <param name="transactionId">The transaction identifier.</param>
+        /// <returns>Response from ArangoDB with the status of a transaction.</returns>
+        Task<PostTransactionResponse<TStreamTransactionResult>> GetTransactionStatus<TStreamTransactionResult>(
+            string transactionId);
+
         /// <summary>
         /// POST a transaction to ArangoDB.
         /// </summary>

--- a/arangodb-net-standard/TransactionApi/Models/PostTransactionBody.cs
+++ b/arangodb-net-standard/TransactionApi/Models/PostTransactionBody.cs
@@ -5,32 +5,12 @@ namespace ArangoDBNetStandard.TransactionApi.Models
     /// <summary>
     /// Represents information required to make a transaction request to ArangoDB.
     /// </summary>
-    public class PostTransactionBody
+    public class PostTransactionBody : StreamTransactionBody
     {
         /// <summary>
         /// JavaScript function describing the transaction action.
         /// </summary>
         public string Action { get; set; }
-
-        /// <summary>
-        /// Collections configuration for the transaction.
-        /// </summary>
-        public PostTransactionRequestCollections Collections { get; set; }
-
-        /// <summary>
-        /// The maximum transaction size before making intermediate commits (RocksDB only).
-        /// </summary>
-        public long? MaxTransactionSize { get; set; }
-
-        /// <summary>
-        /// The maximum time to wait for required locks to be released, before the transaction times out.
-        /// </summary>
-        public long? LockTimeout { get; set; }
-
-        /// <summary>
-        /// 
-        /// </summary>
-        public bool? WaitForSync { get; set; }
 
         /// <summary>
         /// Parameters to be passed into the transaction JavaScript function defined by <see cref="Action"/>.

--- a/arangodb-net-standard/TransactionApi/Models/PostTransactionBody.cs
+++ b/arangodb-net-standard/TransactionApi/Models/PostTransactionBody.cs
@@ -5,12 +5,32 @@ namespace ArangoDBNetStandard.TransactionApi.Models
     /// <summary>
     /// Represents information required to make a transaction request to ArangoDB.
     /// </summary>
-    public class PostTransactionBody : StreamTransactionBody
+    public class PostTransactionBody
     {
         /// <summary>
         /// JavaScript function describing the transaction action.
         /// </summary>
         public string Action { get; set; }
+
+        /// <summary>
+        /// Collections configuration for the transaction.
+        /// </summary>
+        public PostTransactionRequestCollections Collections { get; set; }
+
+        /// <summary>
+        /// The maximum transaction size before making intermediate commits (RocksDB only).
+        /// </summary>
+        public long? MaxTransactionSize { get; set; }
+
+        /// <summary>
+        /// The maximum time to wait for required locks to be released, before the transaction times out.
+        /// </summary>
+        public long? LockTimeout { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public bool? WaitForSync { get; set; }
 
         /// <summary>
         /// Parameters to be passed into the transaction JavaScript function defined by <see cref="Action"/>.

--- a/arangodb-net-standard/TransactionApi/Models/StreamTransactionBody.cs
+++ b/arangodb-net-standard/TransactionApi/Models/StreamTransactionBody.cs
@@ -6,17 +6,27 @@
     public class StreamTransactionBody
     {
         /// <summary>
-        /// Gets or sets the collections configuration for the transaction.
+        /// Gets or sets to allow reading from undeclared collections.
+        /// </summary>
+        public bool AllowImplicit { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="PostTransactionRequestCollections"/> object that can have one or all sub-attributes read, write or exclusive,
+        /// each being an array of collection names.
+        /// Collections that will be written to in the transaction must be declared with the write or exclusive attribute or it will fail,
+        /// whereas non-declared collections from which is solely read will be added lazily.
         /// </summary>
         public PostTransactionRequestCollections Collections { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum time to wait for required locks to be released, before the transaction times out.
+        /// Gets or sets an optional numeric value that can be used to set a timeout for waiting on collection locks.
+        /// If not specified, a default value will be used.
+        /// Setting lockTimeout to 0 will make ArangoDB not time out waiting for a lock.
         /// </summary>
         public long? LockTimeout { get; set; }
 
         /// <summary>
-        /// Gets or sets the maximum transaction size before making intermediate commits (RocksDB only).
+        /// Gets or sets the maximum transaction size limit in bytes. Honored by the RocksDB storage engine only.
         /// </summary>
         public long? MaxTransactionSize { get; set; }
 

--- a/arangodb-net-standard/TransactionApi/Models/StreamTransactionBody.cs
+++ b/arangodb-net-standard/TransactionApi/Models/StreamTransactionBody.cs
@@ -1,0 +1,28 @@
+﻿namespace ArangoDBNetStandard.TransactionApi.Models
+{
+    /// <summary>
+    /// Represents information required to make a stream transaction to begin.
+    /// </summary>
+    public class StreamTransactionBody
+    {
+        /// <summary>
+        /// Gets or sets the collections configuration for the transaction.
+        /// </summary>
+        public PostTransactionRequestCollections Collections { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum time to wait for required locks to be released, before the transaction times out.
+        /// </summary>
+        public long? LockTimeout { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum transaction size before making intermediate commits (RocksDB only).
+        /// </summary>
+        public long? MaxTransactionSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets optional flag to force the transaction to write all data to disk before returning.
+        /// </summary>
+        public bool? WaitForSync { get; set; }
+    }
+}

--- a/arangodb-net-standard/TransactionApi/Models/StreamTransactionResponse.cs
+++ b/arangodb-net-standard/TransactionApi/Models/StreamTransactionResponse.cs
@@ -1,0 +1,25 @@
+﻿using System.Net;
+
+namespace ArangoDBNetStandard.TransactionApi.Models
+{
+    /// <summary>
+    /// Response from ArangoDB after executing a stream transaction.
+    /// </summary>
+    public class StreamTransactionResponse
+    {
+        /// <summary>
+        /// Gets or sets the Http Status code.
+        /// </summary>    
+        public HttpStatusCode Code { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether an error has occured.
+        /// </summary>
+        public bool Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets the deserialized result from the stream transaction result.
+        /// </summary>
+        public StreamTransactionResult Result { get; set; }
+    }
+}

--- a/arangodb-net-standard/TransactionApi/Models/StreamTransactionResponse.cs
+++ b/arangodb-net-standard/TransactionApi/Models/StreamTransactionResponse.cs
@@ -3,7 +3,7 @@
 namespace ArangoDBNetStandard.TransactionApi.Models
 {
     /// <summary>
-    /// Response from ArangoDB after executing a stream transaction.
+    /// Response from ArangoDB after executing a stream transaction operation.
     /// </summary>
     public class StreamTransactionResponse
     {

--- a/arangodb-net-standard/TransactionApi/Models/StreamTransactionResult.cs
+++ b/arangodb-net-standard/TransactionApi/Models/StreamTransactionResult.cs
@@ -1,7 +1,7 @@
 ﻿namespace ArangoDBNetStandard.TransactionApi.Models
 {
     /// <summary>
-    /// Result from ArangoDB after beginning a Stream transaction.
+    /// Result from ArangoDB after performing a Stream transaction operation.
     /// </summary>
     public class StreamTransactionResult
     {

--- a/arangodb-net-standard/TransactionApi/Models/StreamTransactionResult.cs
+++ b/arangodb-net-standard/TransactionApi/Models/StreamTransactionResult.cs
@@ -1,0 +1,18 @@
+﻿namespace ArangoDBNetStandard.TransactionApi.Models
+{
+    /// <summary>
+    /// Result from ArangoDB after beginning a Stream transaction.
+    /// </summary>
+    public class StreamTransactionResult
+    {
+        /// <summary>
+        /// Gets or sets the identifier of the transaction.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the status of the transaction.
+        /// </summary>
+        public StreamTransactionStatus Status { get; set; }
+    }
+}

--- a/arangodb-net-standard/TransactionApi/Models/StreamTransactionStatus.cs
+++ b/arangodb-net-standard/TransactionApi/Models/StreamTransactionStatus.cs
@@ -1,0 +1,23 @@
+﻿namespace ArangoDBNetStandard.TransactionApi.Models
+{
+    /// <summary>
+    /// Enum containing the different stream transaction status.
+    /// </summary>
+    public enum StreamTransactionStatus
+    {
+        /// <summary>
+        /// Transaction is running.
+        /// </summary>
+        Running,
+
+        /// <summary>
+        /// Transaction is committed.
+        /// </summary>
+        Committed,
+
+        /// <summary>
+        /// Transaction is aborted.
+        /// </summary>
+        Aborted,
+    }
+}

--- a/arangodb-net-standard/TransactionApi/Models/StreamTransactions.cs
+++ b/arangodb-net-standard/TransactionApi/Models/StreamTransactions.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.TransactionApi.Models
+{
+    /// <summary>
+    /// Result from ArangoDB after getting list of all running transactions.
+    /// </summary>
+    public class StreamTransactions
+    {
+        /// <summary>
+        /// Gets or sets list of all Stream Transactions.
+        /// </summary>
+        public IList<Transaction> Transactions { get; set; }
+    }
+}

--- a/arangodb-net-standard/TransactionApi/Models/Transaction.cs
+++ b/arangodb-net-standard/TransactionApi/Models/Transaction.cs
@@ -1,0 +1,18 @@
+﻿namespace ArangoDBNetStandard.TransactionApi.Models
+{
+    /// <summary>
+    /// Transaction Properties.
+    /// </summary>
+    public sealed class Transaction
+    {
+        /// <summary>
+        /// Gets or sets the transaction Id.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the transaction status.
+        /// </summary>
+        public StreamTransactionStatus State { get; set; }
+    }
+}

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -1,7 +1,8 @@
-﻿using ArangoDBNetStandard.Serialization;
+﻿using System;
+using System.Threading.Tasks;
+using ArangoDBNetStandard.Serialization;
 using ArangoDBNetStandard.TransactionApi.Models;
 using ArangoDBNetStandard.Transport;
-using System.Threading.Tasks;
 
 namespace ArangoDBNetStandard.TransactionApi
 {
@@ -13,18 +14,29 @@ namespace ArangoDBNetStandard.TransactionApi
         /// <summary>
         /// The transport client used to communicate with the ArangoDB host.
         /// </summary>
-        protected IApiClientTransport _client;
+        private readonly IApiClientTransport _client;
 
         /// <summary>
         /// The root path of the API.
         /// </summary>
-        protected readonly string _transactionApiPath = "_api/transaction";
+        private readonly string _transactionApiPath = "_api/transaction";
 
         /// <summary>
+        /// The root path of the API to abort, commit a transaction and get the status of a transaction.
+        /// </summary>
+        private readonly string _streamTransactionApiPath = "_api/transaction/{0}";
+
+        /// <summary>
+        /// The root path of the API to begin a transaction.
+        /// </summary>
+        private readonly string _beginTransactionApiPath = "_api/transaction/begin";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransactionApiClient"/> class.
         /// Create an instance of <see cref="TransactionApiClient"/>
         /// using the provided transport layer and the default JSON serialization.
         /// </summary>
-        /// <param name="client"></param>
+        /// <param name="client">The ApiClientTransport.</param>
         public TransactionApiClient(IApiClientTransport client)
             : base(new JsonNetApiClientSerialization())
         {
@@ -32,11 +44,12 @@ namespace ArangoDBNetStandard.TransactionApi
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="TransactionApiClient"/> class.
         /// Create an instance of <see cref="TransactionApiClient"/>
         /// using the provided transport and serialization layers.
         /// </summary>
-        /// <param name="client"></param>
-        /// <param name="serializer"></param>
+        /// <param name="client">The ApiClientTransport.</param>
+        /// <param name="serializer">The ApiClientSerialization.</param>
         public TransactionApiClient(IApiClientTransport client, IApiClientSerialization serializer)
             : base(serializer)
         {
@@ -47,7 +60,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// POST a js-transaction to ArangoDB.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/stable/http/transaction-js-transaction.html
+        /// https://www.arangodb.com/docs/stable/http/transaction-js-transaction.html.
         /// </remarks>
         /// <typeparam name="T">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST transaction request.</param>
@@ -63,6 +76,133 @@ namespace ArangoDBNetStandard.TransactionApi
                 {
                     return DeserializeJsonFromStream<PostTransactionResponse<T>>(stream);
                 }
+
+                var error = DeserializeJsonFromStream<ApiErrorResponse>(stream);
+                throw new ApiErrorException(error);
+            }
+        }
+
+        /// <summary>
+        /// Abort a stream transaction by DELETE.
+        /// </summary>
+        /// /// <remarks>
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#abort-transaction.
+        /// </remarks>
+        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
+        /// <param name="transactionId">The transaction identifier.</param>
+        /// <returns>Response from ArangoDB after aborting a transaction.</returns>
+        public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
+            AbortTransaction<TStreamTransactionResult>(string transactionId)
+        {
+            string completeAbortTransactionPath = string.Format(_streamTransactionApiPath, transactionId);
+            using (var response = await _client.DeleteAsync(completeAbortTransactionPath))
+            {
+                var stream = await response.Content.ReadAsStreamAsync();
+                if (response.IsSuccessStatusCode)
+                {
+                    return DeserializeJsonFromStream<PostTransactionResponse<TStreamTransactionResult>>(stream);
+                }
+
+                var error = DeserializeJsonFromStream<ApiErrorResponse>(stream);
+                throw new ApiErrorException(error);
+            }
+        }
+
+        /// <summary>
+        /// Begin a stream transaction by POST.
+        /// </summary>
+        /// <remarks>
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#begin-a-transaction.
+        /// </remarks>
+        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
+        /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
+        /// <returns>Response from ArangoDB after beginning a transaction.</returns>
+        public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
+            BeginTransaction<TStreamTransactionResult>(StreamTransactionBody body)
+        {
+            var content = GetContent(body, new ApiClientSerializationOptions(true, true));
+            using (var response = await _client.PostAsync(_beginTransactionApiPath, content))
+            {
+                var stream = await response.Content.ReadAsStreamAsync();
+                if (response.IsSuccessStatusCode)
+                {
+                    return DeserializeJsonFromStream<PostTransactionResponse<TStreamTransactionResult>>(stream);
+                }
+
+                var error = DeserializeJsonFromStream<ApiErrorResponse>(stream);
+                throw new ApiErrorException(error);
+            }
+        }
+
+        /// <summary>
+        /// Commit a transaction by PUT.
+        /// </summary>
+        /// <remarks>
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#commit-transaction.
+        /// </remarks>
+        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
+        /// <param name="transactionId">The transaction identifier.</param>
+        /// <returns>Response from ArangoDB after committing a transaction.</returns>
+        public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
+            CommitTransaction<TStreamTransactionResult>(string transactionId)
+        {
+            string completeCommitTransactionPath = string.Format(_streamTransactionApiPath, transactionId);
+            using (var response = await _client.PutAsync(completeCommitTransactionPath, Array.Empty<byte>()))
+            {
+                var stream = await response.Content.ReadAsStreamAsync();
+                if (response.IsSuccessStatusCode)
+                {
+                    return DeserializeJsonFromStream<PostTransactionResponse<TStreamTransactionResult>>(stream);
+                }
+
+                var error = DeserializeJsonFromStream<ApiErrorResponse>(stream);
+                throw new ApiErrorException(error);
+            }
+        }
+
+        /// <summary>
+        /// Get currently running transactions.
+        /// </summary>
+        /// <remarks>
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-currently-running-transactions.
+        /// </remarks>
+        /// <returns>Response from ArangoDB with all running transactions.</returns>
+        public virtual async Task<StreamTransactions> GetAllRunningTransactions()
+        {
+            using (var response = await _client.GetAsync(_transactionApiPath))
+            {
+                var stream = await response.Content.ReadAsStreamAsync();
+                if (response.IsSuccessStatusCode)
+                {
+                    return DeserializeJsonFromStream<StreamTransactions>(stream);
+                }
+
+                var error = DeserializeJsonFromStream<ApiErrorResponse>(stream);
+                throw new ApiErrorException(error);
+            }
+        }
+
+        /// <summary>
+        /// Get the status of a transaction.
+        /// </summary>
+        /// <remarks>
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-transaction-status.
+        /// </remarks>
+        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
+        /// <param name="transactionId">The transaction identifier.</param>
+        /// <returns>Response from ArangoDB with the status of a transaction.</returns>
+        public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
+            GetTransactionStatus<TStreamTransactionResult>(string transactionId)
+        {
+            string getTransactionPath = string.Format(_streamTransactionApiPath, transactionId);
+            using (var response = await _client.GetAsync(getTransactionPath))
+            {
+                var stream = await response.Content.ReadAsStreamAsync();
+                if (response.IsSuccessStatusCode)
+                {
+                    return DeserializeJsonFromStream<PostTransactionResponse<TStreamTransactionResult>>(stream);
+                }
+
                 var error = DeserializeJsonFromStream<ApiErrorResponse>(stream);
                 throw new ApiErrorException(error);
             }

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -14,7 +14,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// <summary>
         /// The transport client used to communicate with the ArangoDB host.
         /// </summary>
-        private readonly IApiClientTransport _client;
+        protected IApiClientTransport _client;
 
         /// <summary>
         /// The root path of the API.
@@ -22,21 +22,15 @@ namespace ArangoDBNetStandard.TransactionApi
         private readonly string _transactionApiPath = "_api/transaction";
 
         /// <summary>
-        /// The root path of the API to abort, commit a transaction and get the status of a transaction.
+        /// The root path of the API to abort, begin, commit and get the status of a transaction.
         /// </summary>
         private readonly string _streamTransactionApiPath = "_api/transaction/{0}";
 
         /// <summary>
-        /// The root path of the API to begin a transaction.
-        /// </summary>
-        private readonly string _beginTransactionApiPath = "_api/transaction/begin";
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TransactionApiClient"/> class.
-        /// Create an instance of <see cref="TransactionApiClient"/>
+        /// Create an instance of <see cref="TransactionApiClient"/>.
         /// using the provided transport layer and the default JSON serialization.
         /// </summary>
-        /// <param name="client">The ApiClientTransport.</param>
+        /// <param name="client"></param>
         public TransactionApiClient(IApiClientTransport client)
             : base(new JsonNetApiClientSerialization())
         {
@@ -44,12 +38,11 @@ namespace ArangoDBNetStandard.TransactionApi
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TransactionApiClient"/> class.
-        /// Create an instance of <see cref="TransactionApiClient"/>
+        /// Create an instance of <see cref="TransactionApiClient"/>.
         /// using the provided transport and serialization layers.
         /// </summary>
-        /// <param name="client">The ApiClientTransport.</param>
-        /// <param name="serializer">The ApiClientSerialization.</param>
+        /// <param name="client"></param>
+        /// <param name="serializer"></param>
         public TransactionApiClient(IApiClientTransport client, IApiClientSerialization serializer)
             : base(serializer)
         {
@@ -60,9 +53,8 @@ namespace ArangoDBNetStandard.TransactionApi
         /// POST a js-transaction to ArangoDB.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/stable/http/transaction-js-transaction.html.
+        /// https://www.arangodb.com/docs/stable/http/transaction-js-transaction.html
         /// </remarks>
-        /// <typeparam name="T">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST transaction request.</param>
         /// <returns>Response from ArangoDB after processing the request.</returns>
         public virtual async Task<PostTransactionResponse<T>> PostTransactionAsync<T>(
@@ -86,17 +78,15 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Abort a stream transaction by DELETE.
         /// </summary>
         /// /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#abort-transaction.
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#abort-transaction
         /// </remarks>
-        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 1653 if the transaction cannot be aborted.
         /// With ErrorNum 10 if the transaction is not found.
         /// </exception>
         /// <returns>Response from ArangoDB after aborting a transaction.</returns>
-        public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
-            AbortTransaction<TStreamTransactionResult>(string transactionId)
+        public virtual async Task<StreamTransactionResponse> AbortTransaction(string transactionId)
         {
             string completeAbortTransactionPath = string.Format(_streamTransactionApiPath, transactionId);
             using (var response = await _client.DeleteAsync(completeAbortTransactionPath))
@@ -104,7 +94,7 @@ namespace ArangoDBNetStandard.TransactionApi
                 var stream = await response.Content.ReadAsStreamAsync();
                 if (response.IsSuccessStatusCode)
                 {
-                    return DeserializeJsonFromStream<PostTransactionResponse<TStreamTransactionResult>>(stream);
+                    return DeserializeJsonFromStream<StreamTransactionResponse>(stream);
                 }
 
                 var error = DeserializeJsonFromStream<ApiErrorResponse>(stream);
@@ -116,25 +106,24 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Begin a stream transaction by POST.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#begin-a-transaction.
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#begin-a-transaction
         /// </remarks>
-        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 10 if the <paramref name="body"/> is missing or malformed.
         /// With ErrorNum 1203 if the <paramref name="body"/> contains an unknown collection.
         /// </exception>
         /// <returns>Response from ArangoDB after beginning a transaction.</returns>
-        public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
-            BeginTransaction<TStreamTransactionResult>(StreamTransactionBody body)
+        public virtual async Task<StreamTransactionResponse> BeginTransaction(StreamTransactionBody body)
         {
             var content = GetContent(body, new ApiClientSerializationOptions(true, true));
-            using (var response = await _client.PostAsync(_beginTransactionApiPath, content))
+            string beginTransactionPath = string.Format(_streamTransactionApiPath, "begin");
+            using (var response = await _client.PostAsync(beginTransactionPath, content))
             {
                 var stream = await response.Content.ReadAsStreamAsync();
                 if (response.IsSuccessStatusCode)
                 {
-                    return DeserializeJsonFromStream<PostTransactionResponse<TStreamTransactionResult>>(stream);
+                    return DeserializeJsonFromStream<StreamTransactionResponse>(stream);
                 }
 
                 var error = DeserializeJsonFromStream<ApiErrorResponse>(stream);
@@ -146,17 +135,15 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Commit a transaction by PUT.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#commit-transaction.
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#commit-transaction
         /// </remarks>
-        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">
         /// With ErrorNum 1653 if the transaction cannot be committed.
         /// With ErrorNum 10 if the transaction is not found.
         /// </exception>
         /// <returns>Response from ArangoDB after committing a transaction.</returns>
-        public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
-            CommitTransaction<TStreamTransactionResult>(string transactionId)
+        public virtual async Task<StreamTransactionResponse> CommitTransaction(string transactionId)
         {
             string completeCommitTransactionPath = string.Format(_streamTransactionApiPath, transactionId);
             using (var response = await _client.PutAsync(completeCommitTransactionPath, Array.Empty<byte>()))
@@ -164,7 +151,7 @@ namespace ArangoDBNetStandard.TransactionApi
                 var stream = await response.Content.ReadAsStreamAsync();
                 if (response.IsSuccessStatusCode)
                 {
-                    return DeserializeJsonFromStream<PostTransactionResponse<TStreamTransactionResult>>(stream);
+                    return DeserializeJsonFromStream<StreamTransactionResponse>(stream);
                 }
 
                 var error = DeserializeJsonFromStream<ApiErrorResponse>(stream);
@@ -176,7 +163,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Get currently running transactions.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-currently-running-transactions.
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-currently-running-transactions
         /// </remarks>
         /// <returns>Response from ArangoDB with all running transactions.</returns>
         public virtual async Task<StreamTransactions> GetAllRunningTransactions()
@@ -198,14 +185,12 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Get the status of a transaction.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-transaction-status.
+        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-transaction-status
         /// </remarks>
-        /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>
         /// <returns>Response from ArangoDB with the status of a transaction.</returns>
-        public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
-            GetTransactionStatus<TStreamTransactionResult>(string transactionId)
+        public virtual async Task<StreamTransactionResponse> GetTransactionStatus(string transactionId)
         {
             string getTransactionPath = string.Format(_streamTransactionApiPath, transactionId);
             using (var response = await _client.GetAsync(getTransactionPath))
@@ -213,7 +198,7 @@ namespace ArangoDBNetStandard.TransactionApi
                 var stream = await response.Content.ReadAsStreamAsync();
                 if (response.IsSuccessStatusCode)
                 {
-                    return DeserializeJsonFromStream<PostTransactionResponse<TStreamTransactionResult>>(stream);
+                    return DeserializeJsonFromStream<StreamTransactionResponse>(stream);
                 }
 
                 var error = DeserializeJsonFromStream<ApiErrorResponse>(stream);

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -19,12 +19,12 @@ namespace ArangoDBNetStandard.TransactionApi
         /// <summary>
         /// The root path of the API.
         /// </summary>
-        private readonly string _transactionApiPath = "_api/transaction";
+        protected readonly string _transactionApiPath = "_api/transaction";
 
         /// <summary>
         /// The root path of the API to abort, begin, commit and get the status of a transaction.
         /// </summary>
-        private readonly string _streamTransactionApiPath = "_api/transaction/{0}";
+        protected readonly string _streamTransactionApiPath = "_api/transaction/{0}";
 
         /// <summary>
         /// Create an instance of <see cref="TransactionApiClient"/>.
@@ -55,6 +55,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// <remarks>
         /// https://www.arangodb.com/docs/stable/http/transaction-js-transaction.html
         /// </remarks>
+        /// <typeparam name="T">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST transaction request.</param>
         /// <returns>Response from ArangoDB after processing the request.</returns>
         public virtual async Task<PostTransactionResponse<T>> PostTransactionAsync<T>(
@@ -78,7 +79,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Abort a stream transaction by DELETE.
         /// </summary>
         /// /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#abort-transaction
+        /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#abort-transaction
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">
@@ -106,7 +107,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Begin a stream transaction by POST.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#begin-a-transaction
+        /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#begin-a-transaction
         /// </remarks>
         /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
         /// <exception cref="ApiErrorException">
@@ -135,7 +136,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Commit a transaction by PUT.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#commit-transaction
+        /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#commit-transaction
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">
@@ -163,7 +164,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Get currently running transactions.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-currently-running-transactions
+        /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#get-currently-running-transactions
         /// </remarks>
         /// <returns>Response from ArangoDB with all running transactions.</returns>
         public virtual async Task<StreamTransactions> GetAllRunningTransactions()
@@ -185,7 +186,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// Get the status of a transaction.
         /// </summary>
         /// <remarks>
-        /// https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html#get-transaction-status
+        /// https://www.arangodb.com/docs/stable/http/transaction-stream-transaction.html#get-transaction-status
         /// </remarks>
         /// <param name="transactionId">The transaction identifier.</param>
         /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>

--- a/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
+++ b/arangodb-net-standard/TransactionApi/TransactionApiClient.cs
@@ -90,6 +90,10 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </remarks>
         /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <exception cref="ApiErrorException">
+        /// With ErrorNum 1653 if the transaction cannot be aborted.
+        /// With ErrorNum 10 if the transaction is not found.
+        /// </exception>
         /// <returns>Response from ArangoDB after aborting a transaction.</returns>
         public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
             AbortTransaction<TStreamTransactionResult>(string transactionId)
@@ -116,6 +120,10 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </remarks>
         /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="body">Object containing information to submit in the POST stream transaction request.</param>
+        /// <exception cref="ApiErrorException">
+        /// With ErrorNum 10 if the <paramref name="body"/> is missing or malformed.
+        /// With ErrorNum 1203 if the <paramref name="body"/> contains an unknown collection.
+        /// </exception>
         /// <returns>Response from ArangoDB after beginning a transaction.</returns>
         public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
             BeginTransaction<TStreamTransactionResult>(StreamTransactionBody body)
@@ -142,6 +150,10 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </remarks>
         /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <exception cref="ApiErrorException">
+        /// With ErrorNum 1653 if the transaction cannot be committed.
+        /// With ErrorNum 10 if the transaction is not found.
+        /// </exception>
         /// <returns>Response from ArangoDB after committing a transaction.</returns>
         public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
             CommitTransaction<TStreamTransactionResult>(string transactionId)
@@ -190,6 +202,7 @@ namespace ArangoDBNetStandard.TransactionApi
         /// </remarks>
         /// <typeparam name="TStreamTransactionResult">Type to use for deserializing the object returned by the transaction function.</typeparam>
         /// <param name="transactionId">The transaction identifier.</param>
+        /// <exception cref="ApiErrorException">With ErrorNum 10 if the transaction is not found.</exception>
         /// <returns>Response from ArangoDB with the status of a transaction.</returns>
         public virtual async Task<PostTransactionResponse<TStreamTransactionResult>>
             GetTransactionStatus<TStreamTransactionResult>(string transactionId)


### PR DESCRIPTION
Implemented the Stream Transaction Api using the documentation from Arangodb

https://www.arangodb.com/docs/3.6/http/transaction-stream-transaction.html

Even though the API calls work, the collections gets updated once the transactions begins (or) before committing/aborting.

Added few test cases to check that.