### PR TITLE
Extend coverage of default serialization logic.

### DIFF
--- a/arangodb-net-standard.Test/Serialization/Models/InnerTestModel.cs
+++ b/arangodb-net-standard.Test/Serialization/Models/InnerTestModel.cs
@@ -1,0 +1,9 @@
+﻿namespace ArangoDBNetStandardTest.Serialization.Models
+{
+    public class InnerTestModel
+    {
+        public string InnerTestModel_NullProperty { get; set; }
+
+        public string InnerTestModel_PropertyToCheckIfCamelCase { get; set; }
+    }
+}

--- a/arangodb-net-standard.Test/Serialization/Models/TestModel.cs
+++ b/arangodb-net-standard.Test/Serialization/Models/TestModel.cs
@@ -1,4 +1,7 @@
-﻿namespace ArangoDBNetStandardTest.Serialization.Models
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace ArangoDBNetStandardTest.Serialization.Models
 {
     public class TestModel
     {
@@ -8,10 +11,19 @@
             Two = 2
         }
 
-        public string NullPropertyToIgnore { get; set; }
+        public string NullProperty { get; set; }
 
-        public string PropertyToCamelCase { get; set; }
+        public string AnotherNullProperty { get; set; }
 
-        public Number EnumToConvertToString { get; set; }
+        public string PropertyToCheckIfCamelCase { get; set; }
+
+        public Number EnumToConvert { get; set; }
+
+        [JsonProperty(PropertyName = "nameFromJsonProperty")]
+        public string PropertyWithDifferentJsonName { get; set; }
+
+        public Dictionary<string, object> MyStringDict { get; set; }
+
+        public InnerTestModel PropertyWithClassType { get; set; }
     }
 }


### PR DESCRIPTION
This is to give a clearer view of what to expect when serializing with default options.