### PR TITLE
Support for additional collection endpoints

### DIFF
--- a/arangodb-net-standard.Test/CollectionApi/CollectionApiClientTest.cs
+++ b/arangodb-net-standard.Test/CollectionApi/CollectionApiClientTest.cs
@@ -23,8 +23,6 @@ namespace ArangoDBNetStandardTest.CollectionApi
             _adb = fixture.ArangoDBClient;
             _collectionApi = _adb.Collection;
             _testCollection = fixture.TestCollection;
-
-
         }
 
         public async Task InitializeAsync()
@@ -471,5 +469,55 @@ namespace ArangoDBNetStandardTest.CollectionApi
             });
             Assert.Equal(HttpStatusCode.NotFound, exception.ApiError.Code);
         }
+
+
+
+
+        [Fact]
+        public async Task GetChecksumAsync_ShouldSucceed()
+        {
+            var res = await _collectionApi.GetChecksumAsync(_testCollection);
+            Assert.NotNull(res.Checksum);
+        }
+
+        [Fact]
+        public async Task LoadIndexesIntoMemoryAsync_ShouldSucceed()
+        {
+            var res = await _collectionApi.LoadIndexesIntoMemoryAsync(_testCollection);
+            Assert.True(res.Result);
+        }
+
+        [Fact]
+        public async Task RecalculateCountAsync_ShouldSucceed()
+        {
+            var res = await _collectionApi.RecalculateCountAsync(_testCollection);
+            Assert.True(res.Result);
+        }
+
+        [Fact]
+        public async Task GetCollectionShardsAsync_ShouldSucceed()
+        {
+            var res = await _collectionApi.GetCollectionShardsAsync(_testCollection);
+            Assert.Equal(HttpStatusCode.OK,res.Code);
+        }
+
+        [Fact]
+        public async Task GetCollectionShardsWithDetailsAsync_ShouldSucceed()
+        {
+            var res = await _collectionApi.GetCollectionShardsWithDetailsAsync(_testCollection);
+            Assert.Equal(HttpStatusCode.OK, res.Code);
+        }
+
+        [Fact]
+        public async Task CompactCollectionDataAsync_ShouldSucceed()
+        {
+            var res = await _collectionApi.CompactCollectionDataAsync(_testCollection);
+            Assert.Equal(HttpStatusCode.OK, res.Code);
+            Assert.NotNull(res.GloballyUniqueId);
+        }
+
+
+
+
     }
 }

--- a/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
@@ -269,18 +269,6 @@ namespace ArangoDBNetStandard.CollectionApi
             };
         }
 
-
-
-
-
-
-
-
-
-
-
-
-
         /// <summary>
         /// Get the checksum for a specific collection.
         /// GET /_api/collection/{collection-name}/checksum
@@ -290,7 +278,24 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <returns></returns>
         public virtual async Task<GetChecksumResponse> GetChecksumAsync(string collectionName, GetChecksumQuery query = null)
         {
-            throw new System.NotImplementedException();
+            if (string.IsNullOrWhiteSpace(collectionName))
+            {
+                throw new System.ArgumentNullException("collectionName", "collectionName is required");
+            }
+            string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/checksum";
+            if (query != null)
+            {
+                uriString += "?" + query.ToQueryString();
+            }
+            using (var response = await _transport.GetAsync(uriString).ConfigureAwait(false))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    return DeserializeJsonFromStream<GetChecksumResponse>(stream);
+                }
+                throw await GetApiErrorException(response).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -305,7 +310,20 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <returns></returns>
         public virtual async Task<LoadIndexesIntoMemoryResponse> LoadIndexesIntoMemoryAsync(string collectionName)
         {
-            throw new System.NotImplementedException();
+            if (string.IsNullOrWhiteSpace(collectionName))
+            {
+                throw new System.ArgumentNullException("collectionName", "collectionName is required");
+            }
+            string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/loadIndexesIntoMemory";
+            using (var response = await _transport.PutAsync(uriString, null).ConfigureAwait(false))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    return DeserializeJsonFromStream<LoadIndexesIntoMemoryResponse>(stream);
+                }
+                throw await GetApiErrorException(response).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -316,7 +334,20 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <returns></returns>
         public virtual async Task<RecalculateCountResponse> RecalculateCountAsync(string collectionName)
         {
-            throw new System.NotImplementedException();
+            if (string.IsNullOrWhiteSpace(collectionName))
+            {
+                throw new System.ArgumentNullException("collectionName", "collectionName is required");
+            }
+            string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/recalculateCount";
+            using (var response = await _transport.PutAsync(uriString, null).ConfigureAwait(false))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    return DeserializeJsonFromStream<RecalculateCountResponse>(stream);
+                }
+                throw await GetApiErrorException(response).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -332,7 +363,25 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <returns></returns>
         public virtual async Task<DocumentShardResponse> PutDocumentShardAsync(string collectionName, Dictionary<string, object> body)
         {
-            throw new System.NotImplementedException();
+            if (string.IsNullOrWhiteSpace(collectionName))
+            {
+                throw new System.ArgumentNullException("collectionName", "collectionName is required");
+            }
+            if (body == null)
+            {
+                throw new System.ArgumentNullException("body","body is required");
+            }
+            string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/responsibleShard";
+            var content = GetContent(body, new ApiClientSerializationOptions(true, true));
+            using (var response = await _transport.PutAsync(uriString, content).ConfigureAwait(false))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    return DeserializeJsonFromStream<DocumentShardResponse>(stream);
+                }
+                throw await GetApiErrorException(response).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -344,7 +393,20 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <returns></returns>
         public virtual async Task<CollectionShardsResponse> GetCollectionShardsAsync(string collectionName)
         {
-            throw new System.NotImplementedException();
+            if (string.IsNullOrWhiteSpace(collectionName))
+            {
+                throw new System.ArgumentNullException("collectionName", "collectionName is required");
+            }
+            string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/shards";
+            using (var response = await _transport.GetAsync(uriString).ConfigureAwait(false))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    return DeserializeJsonFromStream<CollectionShardsResponse>(stream);
+                }
+                throw await GetApiErrorException(response).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -359,7 +421,20 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <returns></returns>
         public virtual async Task<CollectionShardsDetailedResponse> GetCollectionShardsWithDetailsAsync(string collectionName)
         {
-            throw new System.NotImplementedException();
+            if (string.IsNullOrWhiteSpace(collectionName))
+            {
+                throw new System.ArgumentNullException("collectionName", "collectionName is required");
+            }
+            string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/shards?details=true";
+            using (var response = await _transport.GetAsync(uriString).ConfigureAwait(false))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    return DeserializeJsonFromStream<CollectionShardsDetailedResponse>(stream);
+                }
+                throw await GetApiErrorException(response).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -372,7 +447,20 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <returns></returns>
         public virtual async Task<CompactCollectionDataResponse> CompactCollectionDataAsync(string collectionName)
         {
-            throw new System.NotImplementedException();
+            if (string.IsNullOrWhiteSpace(collectionName))
+            {
+                throw new System.ArgumentNullException("collectionName", "collectionName is required");
+            }
+            string uriString = _collectionApiPath + "/" + WebUtility.UrlEncode(collectionName) + "/shards?details=true";
+            using (var response = await _transport.PutAsync(uriString,null).ConfigureAwait(false))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                    return DeserializeJsonFromStream<CompactCollectionDataResponse>(stream);
+                }
+                throw await GetApiErrorException(response).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/CollectionApiClient.cs
@@ -1,6 +1,7 @@
 ﻿using ArangoDBNetStandard.CollectionApi.Models;
 using ArangoDBNetStandard.Serialization;
 using ArangoDBNetStandard.Transport;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -266,6 +267,112 @@ namespace ArangoDBNetStandard.CollectionApi
 
                 throw await GetApiErrorException(response).ConfigureAwait(false);
             };
+        }
+
+
+
+
+
+
+
+
+
+
+
+
+
+        /// <summary>
+        /// Get the checksum for a specific collection.
+        /// GET /_api/collection/{collection-name}/checksum
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="query">Query options.</param>
+        /// <returns></returns>
+        public virtual async Task<GetChecksumResponse> GetChecksumAsync(string collectionName, GetChecksumQuery query = null)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Load Indexes into Memory.
+        /// Caches all index entries of this collection into the main memory. 
+        /// Therefore it iterates over all indexes of the collection and 
+        /// stores the indexed values, not the entire document data, 
+        /// in memory.
+        /// PUT /_api/collection/{collection-name}/loadIndexesIntoMemory
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
+        public virtual async Task<LoadIndexesIntoMemoryResponse> LoadIndexesIntoMemoryAsync(string collectionName)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Recalculates the document count of a collection.        
+        /// PUT /_api/collection/{collection-name}/recalculateCount
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
+        public virtual async Task<RecalculateCountResponse> RecalculateCountAsync(string collectionName)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns the responsible shard for a document.        
+        /// PUT /_api/collection/{collection-name}/responsibleShard
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="body">
+        /// Body of the request consisting of key/value
+        /// pairs with at least the collection’s shard 
+        /// key attributes set to some values.
+        /// </param>
+        /// <returns></returns>
+        public virtual async Task<DocumentShardResponse> PutDocumentShardAsync(string collectionName, Dictionary<string, object> body)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns the shard ids of a collection.
+        /// This method is only available in a cluster Coordinator.
+        /// GET /_api/collection/{collection-name}/shards
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
+        public virtual async Task<CollectionShardsResponse> GetCollectionShardsAsync(string collectionName)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Returns the shard ids of a collection.
+        /// This method is only available in a cluster Coordinator.
+        /// The response also contains shard IDs as object attribute 
+        /// keys, and the responsible servers for each shard mapped 
+        /// to them. The leader shards will be first in the arrays.
+        /// GET /_api/collection/{collection-name}/shards?details=true
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
+        public virtual async Task<CollectionShardsDetailedResponse> GetCollectionShardsWithDetailsAsync(string collectionName)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        /// <summary>
+        /// Compacts the data of a collection in order to reclaim disk space.
+        /// The operation will compact the document and index data by rewriting
+        /// the underlying .sst files and only keeping the relevant entries. 
+        /// PUT /_api/collection/{collection-name}/compact
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
+        public virtual async Task<CompactCollectionDataResponse> CompactCollectionDataAsync(string collectionName)
+        {
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/arangodb-net-standard/CollectionApi/ICollectionApiClient.cs
+++ b/arangodb-net-standard/CollectionApi/ICollectionApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using ArangoDBNetStandard.CollectionApi.Models;
 using ArangoDBNetStandard.Serialization;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace ArangoDBNetStandard.CollectionApi
@@ -92,5 +93,85 @@ namespace ArangoDBNetStandard.CollectionApi
         /// <param name="collectionName"></param>
         /// <returns></returns>
         Task<GetCollectionFiguresResponse> GetCollectionFiguresAsync(string collectionName);
+
+        /// <summary>
+        /// Get the checksum for a specific collection.
+        /// GET /_api/collection/{collection-name}/checksum
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="query">Query options.</param>
+        /// <returns></returns>
+        Task<GetChecksumResponse> GetChecksumAsync(string collectionName, 
+            GetChecksumQuery query = null);
+
+        /// <summary>
+        /// Load Indexes into Memory.
+        /// Caches all index entries of this collection into the main memory. 
+        /// Therefore it iterates over all indexes of the collection and 
+        /// stores the indexed values, not the entire document data, 
+        /// in memory.
+        /// PUT /_api/collection/{collection-name}/loadIndexesIntoMemory
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
+        Task<LoadIndexesIntoMemoryResponse> LoadIndexesIntoMemoryAsync(
+           string collectionName);
+
+        /// <summary>
+        /// Recalculates the document count of a collection.        
+        /// PUT /_api/collection/{collection-name}/recalculateCount
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
+        Task<RecalculateCountResponse> RecalculateCountAsync(
+           string collectionName);
+
+        /// <summary>
+        /// Returns the responsible shard for a document.        
+        /// PUT /_api/collection/{collection-name}/responsibleShard
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <param name="body">
+        /// Body of the request consisting of key/value
+        /// pairs with at least the collection’s shard 
+        /// key attributes set to some values.
+        /// </param>
+        /// <returns></returns>
+        Task<DocumentShardResponse> PutDocumentShardAsync(
+           string collectionName, Dictionary<string,object> body);
+
+        /// <summary>
+        /// Returns the shard ids of a collection.
+        /// This method is only available in a cluster Coordinator.
+        /// GET /_api/collection/{collection-name}/shards
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
+        Task<CollectionShardsResponse> GetCollectionShardsAsync(
+           string collectionName);
+
+        /// <summary>
+        /// Returns the shard ids of a collection.
+        /// This method is only available in a cluster Coordinator.
+        /// The response also contains shard IDs as object attribute 
+        /// keys, and the responsible servers for each shard mapped 
+        /// to them. The leader shards will be first in the arrays.
+        /// GET /_api/collection/{collection-name}/shards?details=true
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
+        Task<CollectionShardsDetailedResponse> GetCollectionShardsWithDetailsAsync(
+           string collectionName);
+
+        /// <summary>
+        /// Compacts the data of a collection in order to reclaim disk space.
+        /// The operation will compact the document and index data by rewriting
+        /// the underlying .sst files and only keeping the relevant entries. 
+        /// PUT /_api/collection/{collection-name}/compact
+        /// </summary>
+        /// <param name="collectionName">Name of the collection.</param>
+        /// <returns></returns>
+        Task<CompactCollectionDataResponse> CompactCollectionDataAsync(
+           string collectionName);
     }
 }

--- a/arangodb-net-standard/CollectionApi/Models/CollectionShardsDetailedResponse.cs
+++ b/arangodb-net-standard/CollectionApi/Models/CollectionShardsDetailedResponse.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    public class CollectionShardsDetailedResponse : CollectionShardsResponseBase
+    {
+        public Dictionary<string,List<string>> Shards { get; set; }
+    }
+}

--- a/arangodb-net-standard/CollectionApi/Models/CollectionShardsKeyOption.cs
+++ b/arangodb-net-standard/CollectionApi/Models/CollectionShardsKeyOption.cs
@@ -1,0 +1,9 @@
+﻿namespace ArangoDBNetStandard.CollectionApi.Models
+{
+
+    public class CollectionShardsKeyOption
+    {
+        public bool? AllowUserKeys { get; set; }
+        public string Type { get; set; }
+    }
+}

--- a/arangodb-net-standard/CollectionApi/Models/CollectionShardsResponse.cs
+++ b/arangodb-net-standard/CollectionApi/Models/CollectionShardsResponse.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    public class CollectionShardsResponse : CollectionShardsResponseBase
+    {
+        public List<string> Shards { get; set; }
+    }
+}

--- a/arangodb-net-standard/CollectionApi/Models/CollectionShardsResponseBase.cs
+++ b/arangodb-net-standard/CollectionApi/Models/CollectionShardsResponseBase.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    public class CollectionShardsResponseBase : ResponseBase
+    {
+        public bool? WaitForSync { get; set; }
+        public string ShardingStrategy { get; set; }
+        public bool? UsesRevisionsAsDocumentIds { get; set; }
+        public object Schema { get; set; }
+        public int? WriteConcern { get; set; }
+        public bool? SyncByRevision { get; set; }
+        public int? ReplicationFactor { get; set; }
+        public int? NumberOfShards { get; set; }
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public bool? IsDisjoint { get; set; }
+        public int? MinReplicationFactor { get; set; }
+        public int? Status { get; set; }
+        public int? Type { get; set; }
+        public string GloballyUniqueId { get; set; }
+        public bool? IsSmart { get; set; }
+        public bool? IsSystem { get; set; }
+        public int? InternalValidatorType { get; set; }
+        public bool? IsSmartChild { get; set; }
+        public string StatusString { get; set; }
+        public bool? CacheEnabled { get; set; }
+        public List<string> ShardKeys { get; set; }
+        public CollectionShardsKeyOption KeyOptions { get; set; }
+    }
+}

--- a/arangodb-net-standard/CollectionApi/Models/CompactCollectionDataResponse.cs
+++ b/arangodb-net-standard/CollectionApi/Models/CompactCollectionDataResponse.cs
@@ -1,0 +1,12 @@
+﻿namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    public class CompactCollectionDataResponse : ResponseBase
+    {
+        public int? Type { get; set; }
+        public int? Status { get; set; }
+        public bool? IsSystem { get; set; }
+        public string Name { get; set; }
+        public string Id { get; set; }
+        public string GloballyUniqueId { get; set; }
+    }
+}

--- a/arangodb-net-standard/CollectionApi/Models/DocumentShardResponse.cs
+++ b/arangodb-net-standard/CollectionApi/Models/DocumentShardResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    public class DocumentShardResponse : ResponseBase
+    {
+        /// <summary>
+        /// The Id of the responsible shard.
+        /// </summary>
+        public string ShardId { get; set; }
+    }
+}

--- a/arangodb-net-standard/CollectionApi/Models/GetChecksumQuery.cs
+++ b/arangodb-net-standard/CollectionApi/Models/GetChecksumQuery.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    /// <summary>
+    /// Generates query for <see cref="ICollectionApiClient.GetChecksumAsync(string, GetChecksumQuery)"/>
+    /// </summary>
+    public class GetChecksumQuery
+    {
+        /// <summary>
+        /// Optional. Indicates whether or not to include document 
+        /// revision ids in the checksum calculation.
+        /// When true, then revision ids (_rev system attributes)
+        /// are included in the checksumming.
+        /// </summary>
+        public bool? WithRevisions { get; set; }
+
+        /// <summary>
+        /// Optional. Indicates whether or not to include document 
+        /// body data in the checksum calculation.
+        /// When true, the user-defined document attributes will
+        /// be included in the calculation too.
+        /// Note: Including user-defined attributes will 
+        /// make the checksumming slower.
+        /// </summary>
+        public bool? WithData { get; set; }
+
+        internal string ToQueryString()
+        {
+            List<string> query = new List<string>();
+            if (WithRevisions != null)
+            {
+                query.Add("withRevisions=" + WithRevisions.ToString().ToLower());
+            }
+            if (WithData != null)
+            {
+                query.Add("withData=" + WithData.ToString().ToLower());
+            }
+            return string.Join("&", query);
+        }
+    }
+}

--- a/arangodb-net-standard/CollectionApi/Models/GetChecksumResponse.cs
+++ b/arangodb-net-standard/CollectionApi/Models/GetChecksumResponse.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    /// <summary>
+    /// Response from <see cref="ICollectionApiClient.GetChecksumAsync(string, GetChecksumQuery)"/>
+    /// </summary>
+    public class GetChecksumResponse:ResponseBase
+    {
+        /// <summary>
+        /// The GUID of the collection.
+        /// </summary>
+        public string GloballyUniqueId { get; set; }
+
+        /// <summary>
+        /// Indicates whether it is a system collection.
+        /// </summary>
+        public bool? IsSystem { get; set; }
+
+        /// <summary>
+        /// The collection type.
+        /// </summary>
+        public int? Type { get; set; }
+
+        /// <summary>
+        /// The collection status.
+        /// </summary>
+        public int? Status { get; set; }
+
+        /// <summary>
+        /// The name of the collection.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The Id of the collection.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The collection revision id.
+        /// </summary>
+        public string Revision { get; set; }
+
+        /// <summary>
+        /// The calculated checksum.
+        /// </summary>
+        public string Checksum { get; set; }
+    }
+}

--- a/arangodb-net-standard/CollectionApi/Models/LoadIndexesIntoMemoryResponse.cs
+++ b/arangodb-net-standard/CollectionApi/Models/LoadIndexesIntoMemoryResponse.cs
@@ -1,0 +1,13 @@
+﻿using System.Net;
+
+namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    public class LoadIndexesIntoMemoryResponse:ResponseBase
+    {
+        /// <summary>
+        /// Indicates whether the operation
+        /// was successful or not.
+        /// </summary>
+        public bool? Result { get; set; }
+    }
+}

--- a/arangodb-net-standard/CollectionApi/Models/RecalculateCountResponse.cs
+++ b/arangodb-net-standard/CollectionApi/Models/RecalculateCountResponse.cs
@@ -1,0 +1,12 @@
+﻿namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    public class RecalculateCountResponse
+    {
+        /// <summary>
+        /// Indicates if recalculating 
+        /// the document count succeeded.
+        /// </summary>
+        public bool? Result { get; set; }
+    }
+
+}

--- a/arangodb-net-standard/CollectionApi/Models/ResponseBase.cs
+++ b/arangodb-net-standard/CollectionApi/Models/ResponseBase.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace ArangoDBNetStandard.CollectionApi.Models
+{
+    /// <summary>
+    /// Represents a common response class for API operations.
+    /// </summary>
+    public class ResponseBase
+    {
+        /// <summary>
+        /// Indicates whether an error occurred
+        /// </summary>
+        public bool? Error { get; set; }
+
+        /// <summary>
+        /// The HTTP status code.
+        /// </summary>
+        public HttpStatusCode Code { get; set; }
+    }
+}

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -198,3 +198,12 @@ A tick indicates an item is implemented and has automated tests in place.
 - [X]	`GET/_api/query/current` Returns the currently running AQL queries
 - [X]	`GET/_api/query/properties` Returns the properties for the AQL query tracking
 - [X]	`PUT/_api/query/properties` Changes the properties for the AQL query tracking
+
+#### Collections API
+
+- [X]	`GET/_api/collection/{collection-name}/checksum` Return checksum for the collection
+- [X]	`PUT/_api/collection/{collection-name}/loadIndexesIntoMemory` Load Indexes into Memory
+- [X]	`PUT/_api/collection/{collection-name}/recalculateCount` Recalculate count of a collection
+- [X]	`PUT​/_api​/collection​/{collection-name}​/responsibleShard` Return responsible shard for a document
+- [X]	`GET/_api/collection/{collection-name}/shards` Return the shard ids of a collection
+- [X]	`PUT/_api/collection/{collection-name}/compact` Compact a collection


### PR DESCRIPTION
`GET/_api/collection/{collection-name}/checksum` Return checksum for the collection
`PUT/_api/collection/{collection-name}/loadIndexesIntoMemory` Load Indexes into Memory
`PUT/_api/collection/{collection-name}/recalculateCount` Recalculate count of a collection
`PUT​/_api​/collection​/{collection-name}​/responsibleShard` Return responsible shard for a document
`GET/_api/collection/{collection-name}/shards` Return the shard ids of a collection
`PUT/_api/collection/{collection-name}/compact` Compact a collection