### PR TITLE
PostCursorOptions - Support Additional Custom Options

### DIFF
--- a/arangodb-net-standard.Test/Serialization/JsonNetApiClientSerializationTest.cs
+++ b/arangodb-net-standard.Test/Serialization/JsonNetApiClientSerializationTest.cs
@@ -308,6 +308,37 @@ namespace ArangoDBNetStandardTest.Serialization
             Assert.Equal("something", model.NullProperty);
         }
 
+        [Fact]
+        public void Serialize_ShouldIncludeAdditionalOptions_WhenSerializingPostCursorOptions()
+        {
+            var body = new PostCursorBody
+            {
+                Options = new PostCursorOptions
+                {
+                    FullCount = true,
+                    AdditionalOptions = new Dictionary<string, object>
+                    {
+                        ["fullCount"] = false,
+                        ["customFlag"] = false,
+                        ["oneShardAttributeValue"] = "tenant-123"
+                    }
+                }
+            };
+
+            var serialization = new JsonNetApiClientSerialization();
+            byte[] jsonBytes = serialization.Serialize(body, new ApiClientSerializationOptions(
+                useCamelCasePropertyNames: true, ignoreNullValues: true));
+            string jsonString = Encoding.UTF8.GetString(jsonBytes);
+
+            // Ensure custom additional options are present
+            Assert.Contains("\"customFlag\":false", jsonString);
+            Assert.Matches("\"fullCount\":true.*\"fullCount\":false", jsonString);
+            Assert.Contains("\"oneShardAttributeValue\":\"tenant-123\"", jsonString);
+
+            // Ensure the AdditionalOptions property itself is not present
+            Assert.DoesNotContain("\"additionalOptions\"", jsonString);
+        }
+
         private void AssertDefaultOptions(ApiClientSerializationOptions options)
         {
             Assert.False(options.UseCamelCasePropertyNames);

--- a/arangodb-net-standard/CursorApi/Models/PostCursorOptions.cs
+++ b/arangodb-net-standard/CursorApi/Models/PostCursorOptions.cs
@@ -1,7 +1,11 @@
-﻿namespace ArangoDBNetStandard.CursorApi.Models
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace ArangoDBNetStandard.CursorApi.Models
 {
     /// <summary>
     /// Represents extra options for the AQL query.
+    /// AdditionalOptions can hold arbitrary server options (flattened via JsonExtensionData).
     /// </summary>
     public class PostCursorOptions
     {
@@ -119,5 +123,12 @@
         /// This feature is only available in the Enterprise Edition.
         /// </summary>
         public bool? SkipInaccessibleCollections { get; set; }
+
+        /// <summary>
+        /// Arbitrary additional options not (yet) modeled as strongly typed properties.
+        /// Entries are serialized at the same level as known properties (flattened).
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalOptions { get; set; }
     }
 }


### PR DESCRIPTION
Allows passing custom (non-strongly typed in `PostCursorOptions`) options for `PostCursorAsync`.

This is a native implementation that does not handle duplicates between the strongly typed properties and the additional options. For example, if `FullCount` is included in the additional options, it will appear twice in the serialized JSON—first with the strongly typed value and again with the value from the additional properties dictionary.

Clarification: I personally need either that feature or the [ForceOneShardAttributeValue support feature PR](https://github.com/ArangoDB-Community/arangodb-net-standard/pull/512) to support the `forceOneShardAttributeValue` option. I've created both approaches for your convenience, but both will work for me.