### PR TITLE
PostCursorOptions - ForceOneShardAttributeValue Option

### DIFF
--- a/arangodb-net-standard/CursorApi/Models/PostCursorOptions.cs
+++ b/arangodb-net-standard/CursorApi/Models/PostCursorOptions.cs
@@ -119,5 +119,14 @@
         /// This feature is only available in the Enterprise Edition.
         /// </summary>
         public bool? SkipInaccessibleCollections { get; set; }
+
+        /// <summary>
+        /// This query option can be used in complex queries in case the query optimizer cannot
+        /// automatically detect that the query can be limited to only a single DBServer (e.g., in a
+        /// disjoint smart graph case). Set this to the shard key value that should be used to force
+        /// execution on one shard. If set incorrectly (i.e., a wrong shard key value), the query may
+        /// be shipped to the wrong DBServer and return no results (empty result set). Use at your own risk.
+        /// </summary>
+        public string ForceOneShardAttributeValue { get; set; }
     }
 }


### PR DESCRIPTION
See:

- Option docs in the Java driver: [link](https://javadoc.io/doc/com.arangodb/arangodb-java-driver/latest/com/arangodb/model/AqlQueryOptions.html#forceOneShardAttributeValue(java.lang.String))
- Option docs in the Golang driver: [link](https://pkg.go.dev/github.com/arangodb/go-driver#WithQueryForceOneShardAttributeValue)